### PR TITLE
Create `BaseEntity` and `LongIdEntity` - closes #10

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/model/common/entity/BaseEntity.java
+++ b/src/main/java/com/askie01/recipeapplication/model/common/entity/BaseEntity.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.model.common.entity;
+
+import com.askie01.recipeapplication.model.common.Identifiable;
+
+public interface BaseEntity <ID>
+        extends Identifiable<ID> {
+}

--- a/src/main/java/com/askie01/recipeapplication/model/common/entity/LongIdEntity.java
+++ b/src/main/java/com/askie01/recipeapplication/model/common/entity/LongIdEntity.java
@@ -1,0 +1,5 @@
+package com.askie01.recipeapplication.model.common.entity;
+
+public interface LongIdEntity
+        extends BaseEntity<Long> {
+}


### PR DESCRIPTION
* Created two interfaces for future entities to use.
* `BaseEntity` interface have generic `id` field.
* `LongIdEntity` interface extends `BaseEntity` and specifies `id` type as `Long`.