### PR TITLE
Create `Ingredient` entity - closes #9

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/model/entity/Ingredient.java
+++ b/src/main/java/com/askie01/recipeapplication/model/entity/Ingredient.java
@@ -1,0 +1,58 @@
+package com.askie01.recipeapplication.model.entity;
+
+import com.askie01.recipeapplication.model.common.LocalDateTimeStringAuditable;
+import com.askie01.recipeapplication.model.common.LongVersionable;
+import com.askie01.recipeapplication.model.common.StringNameable;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Entity
+@Table(name = "ingredient")
+public class Ingredient implements
+        LongIdEntity,
+        StringNameable,
+        LocalDateTimeStringAuditable,
+        LongVersionable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private Double amount;
+
+    @ManyToOne
+    private MeasureUnit measureUnit;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedDate
+    @Column(insertable = false)
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(insertable = false)
+    private String updatedBy;
+
+    @Version
+    private Long version;
+}


### PR DESCRIPTION
* Created `Ingredient` entity with all required fields, including many-to-one mapping for `MeasureUnit` entity.
* Closed #9 