### PR TITLE
Create `ErrorHttpResponse` - close #33

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/response/ErrorHttpResponse.java
+++ b/src/main/java/com/askie01/recipeapplication/response/ErrorHttpResponse.java
@@ -1,0 +1,20 @@
+package com.askie01.recipeapplication.response;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+public class ErrorHttpResponse implements HttpResponse {
+    private String path;
+    private Integer code;
+    private String message;
+    private LocalDateTime timestamp;
+}


### PR DESCRIPTION
* Created implementation class of `HttpResponse` for error responses during request processing.
* We will mostly use this class in RestControllerAdvice responses.
* Apart from `code` & `message` fields required by `HttpResponse` interface - added `path` & `timestamp` fields to see when the error occurred, and executing which endpoint.
* Closed #33 