### PR TITLE
Add validation in `CategoryDTO` - close #50

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/dto/CategoryDTO.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/CategoryDTO.java
@@ -3,6 +3,8 @@ package com.askie01.recipeapplication.dto;
 import com.askie01.recipeapplication.model.common.LongIdentifiable;
 import com.askie01.recipeapplication.model.common.LongVersionable;
 import com.askie01.recipeapplication.model.common.StringNameable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
@@ -14,7 +16,13 @@ import lombok.experimental.SuperBuilder;
 @ToString
 @EqualsAndHashCode
 public class CategoryDTO implements LongIdentifiable, StringNameable, LongVersionable {
+
+    @Positive(message = "Id in 'CategoryDTO' have to be a positive number.")
     private Long id;
+
+    @NotBlank(message = "Name in 'CategoryDTO' can't be empty, blank nor null.")
     private String name;
+
+    @Positive(message = "Version in 'CategoryDTO' must be a positive number.")
     private Long version;
 }


### PR DESCRIPTION
* Added hibernate validation annotations to make sure the data passed in requests and mapped to this DTO is considered `valid` - aka matches the criteria for a successful `Category` persistence.
* This commit closes #50