### PR TITLE
Add `component.auditor.type` property in `application.yaml`- close #62

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,3 +21,7 @@ spring:
   data:
     jdbc:
       dialect: mysql
+
+component:
+  auditor:
+    type: service


### PR DESCRIPTION
* Added new custom property, that will be used to define multiple components, for easier bean-wiring in the future.
* For now, we only have auditor specified, but this will change in the future.
* This commit closes #62