### PR TITLE
Enable jpa auditing - close #64

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/RecipeApplication.java
+++ b/src/main/java/com/askie01/recipeapplication/RecipeApplication.java
@@ -2,7 +2,9 @@ package com.askie01.recipeapplication;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class RecipeApplication {
     public static void main(String[] args) {


### PR DESCRIPTION
* Added `@EnableJpaAuditing` annotation in the main class, to enable jpa auditing where auditor would be current `AuditorAware` bean.
* This commit closes #64