### PR TITLE
Create `StringNameValidator` interface - close #119

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/validator/StringNameValidator.java
+++ b/src/main/java/com/askie01/recipeapplication/validator/StringNameValidator.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.validator;
+
+import com.askie01.recipeapplication.model.value.HasStringName;
+
+public interface StringNameValidator extends Validator<HasStringName> {
+
+}


### PR DESCRIPTION
* Created `StringNameValidator` interface that extends `Validator` interface with `HasStringName` argument.
* We will use further implementations of this interface to perform validation checks on `name` field in `HasStringName` object.
* This commit closes #119