### PR TITLE
Create `ImageMapper` interface - close #113

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/mapper/ImageMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/ImageMapper.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.model.value.HasImage;
+
+public interface ImageMapper extends Mapper<HasImage, HasImage> {
+
+}


### PR DESCRIPTION
* Created `ImageMapper` interface to perform `image` field mapping between 2 `HasImage` objects.
* This commit closes #113