### PR TITLE
Create `StringNameMapper` interface - close #117

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/mapper/StringNameMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/StringNameMapper.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.model.value.HasStringName;
+
+public interface StringNameMapper extends Mapper<HasStringName, HasStringName> {
+
+}


### PR DESCRIPTION
* Created a simple `StringNameMapper` interface to perform `name` field mapping from one `HasStringName` object to another.
* This commit closes #117