### PR TITLE
Create `CookingTimeMapper` interface - close #137

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/mapper/CookingTimeMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/CookingTimeMapper.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.model.value.HasCookingTime;
+
+public interface CookingTimeMapper extends Mapper<HasCookingTime, HasCookingTime> {
+
+}


### PR DESCRIPTION
* Created `CookingTimeMapper` interface to perform `cookingTime` field mapping from one `HasCookingTime` object to another.
* This pull request should close #137