### PR TITLE
Create `InstructionsMapper` interface - close #141

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/mapper/InstructionsMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/InstructionsMapper.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.model.value.HasInstructions;
+
+public interface InstructionsMapper extends Mapper<HasInstructions, HasInstructions> {
+
+}


### PR DESCRIPTION
* Created `InstructionsMapper` interface to perform mapping from one `HasInstructions` object to another.
* This pull request closes #141