### PR TITLE
Create `LongVersionMapper` interface - close #145

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/mapper/LongVersionMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/LongVersionMapper.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.model.value.HasLongVersion;
+
+public interface LongVersionMapper extends Mapper<HasLongVersion, HasLongVersion> {
+
+}


### PR DESCRIPTION
* Created `LongVersionMapper` interface to perform mapping between 2 `HasLongVersion` objects.
* This pull request closes #145