### PR TITLE
Create `CategoryDTOToCategoryMapper` interface - close #123

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/mapper/CategoryDTOToCategoryMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/CategoryDTOToCategoryMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CategoryDTO;
+import com.askie01.recipeapplication.model.entity.Category;
+
+public interface CategoryDTOToCategoryMapper extends
+        Mapper<CategoryDTO, Category>,
+        ToEntityMapper<CategoryDTO, Category> {
+}


### PR DESCRIPTION
* Created a simple `CategoryDTOToCategoryMapper` interface to perform mapping from `CategoryDTO` object to `Category` object.
* This pull request closes #123