### PR TITLE
Create `MeasureUnitDTOToMeasureUnitMapper` interface - close #131

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/mapper/MeasureUnitDTOToMeasureUnitMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/MeasureUnitDTOToMeasureUnitMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.MeasureUnitDTO;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+
+public interface MeasureUnitDTOToMeasureUnitMapper extends
+        Mapper<MeasureUnitDTO, MeasureUnit>,
+        ToEntityMapper<MeasureUnitDTO, MeasureUnit> {
+}


### PR DESCRIPTION
* Created a simple `MeasureUnitDTOToMeasureUnitMapper` interface to perform mapping from `MeasureUnitDTO` object to `MeasureUnit` object.
* This pull request closes #131