### PR TITLE
Rename all test builders - close #206

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/builder/HasCookingTimeTestBuilder.java
+++ b/src/test/java/com/askie01/recipeapplication/builder/HasCookingTimeTestBuilder.java
@@ -10,6 +10,6 @@ import lombok.*;
 @Builder
 @ToString
 @EqualsAndHashCode
-public class TestHasCookingTimeBuilder implements HasCookingTime {
+public class HasCookingTimeTestBuilder implements HasCookingTime {
     private Integer cookingTime;
 }

--- a/src/test/java/com/askie01/recipeapplication/builder/HasImageTestBuilder.java
+++ b/src/test/java/com/askie01/recipeapplication/builder/HasImageTestBuilder.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.builder;
 
-import com.askie01.recipeapplication.model.value.HasStringName;
+import com.askie01.recipeapplication.model.value.HasImage;
 import lombok.*;
 
 @Getter
@@ -10,6 +10,6 @@ import lombok.*;
 @Builder
 @ToString
 @EqualsAndHashCode
-public class TestHasStringNameBuilder implements HasStringName {
-    private String name;
+public class HasImageTestBuilder implements HasImage {
+    private byte[] image;
 }

--- a/src/test/java/com/askie01/recipeapplication/builder/HasInstructionsTestBuilder.java
+++ b/src/test/java/com/askie01/recipeapplication/builder/HasInstructionsTestBuilder.java
@@ -10,6 +10,6 @@ import lombok.*;
 @Builder
 @ToString
 @EqualsAndHashCode
-public class TestHasInstructionsBuilder implements HasInstructions {
+public class HasInstructionsTestBuilder implements HasInstructions {
     private String instructions;
 }

--- a/src/test/java/com/askie01/recipeapplication/builder/HasLongIdTestBuilder.java
+++ b/src/test/java/com/askie01/recipeapplication/builder/HasLongIdTestBuilder.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.builder;
 
-import com.askie01.recipeapplication.model.value.HasLongVersion;
+import com.askie01.recipeapplication.model.value.HasLongId;
 import lombok.*;
 
 @Getter
@@ -10,6 +10,6 @@ import lombok.*;
 @Builder
 @ToString
 @EqualsAndHashCode
-public class TestHasLongVersionBuilder implements HasLongVersion {
-    private Long version;
+public class HasLongIdTestBuilder implements HasLongId {
+    private Long id;
 }

--- a/src/test/java/com/askie01/recipeapplication/builder/HasLongVersionTestBuilder.java
+++ b/src/test/java/com/askie01/recipeapplication/builder/HasLongVersionTestBuilder.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.builder;
 
-import com.askie01.recipeapplication.model.value.HasServings;
+import com.askie01.recipeapplication.model.value.HasLongVersion;
 import lombok.*;
 
 @Getter
@@ -10,6 +10,6 @@ import lombok.*;
 @Builder
 @ToString
 @EqualsAndHashCode
-public class TestHasServingsBuilder implements HasServings {
-    private Double servings;
+public class HasLongVersionTestBuilder implements HasLongVersion {
+    private Long version;
 }

--- a/src/test/java/com/askie01/recipeapplication/builder/HasServingsTestBuilder.java
+++ b/src/test/java/com/askie01/recipeapplication/builder/HasServingsTestBuilder.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.builder;
 
-import com.askie01.recipeapplication.model.value.HasLongId;
+import com.askie01.recipeapplication.model.value.HasServings;
 import lombok.*;
 
 @Getter
@@ -10,6 +10,6 @@ import lombok.*;
 @Builder
 @ToString
 @EqualsAndHashCode
-public class TestHasLongIdBuilder implements HasLongId {
-    private Long id;
+public class HasServingsTestBuilder implements HasServings {
+    private Double servings;
 }

--- a/src/test/java/com/askie01/recipeapplication/builder/HasStringNameTestBuilder.java
+++ b/src/test/java/com/askie01/recipeapplication/builder/HasStringNameTestBuilder.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.builder;
 
-import com.askie01.recipeapplication.model.value.HasImage;
+import com.askie01.recipeapplication.model.value.HasStringName;
 import lombok.*;
 
 @Getter
@@ -10,6 +10,6 @@ import lombok.*;
 @Builder
 @ToString
 @EqualsAndHashCode
-public class TestHasImageBuilder implements HasImage {
-    private byte[] image;
+public class HasStringNameTestBuilder implements HasStringName {
+    private String name;
 }

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedCookingTimeMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedCookingTimeMapperIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasCookingTimeBuilder;
+import com.askie01.recipeapplication.builder.HasCookingTimeTestBuilder;
 import com.askie01.recipeapplication.configuration.PositiveCookingTimeValidatorConfiguration;
 import com.askie01.recipeapplication.configuration.ValidatedCookingTimeMapperConfiguration;
 import com.askie01.recipeapplication.mapper.CookingTimeMapper;
@@ -40,10 +40,10 @@ class ValidatedCookingTimeMapperIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        this.source = TestHasCookingTimeBuilder.builder()
+        this.source = HasCookingTimeTestBuilder.builder()
                 .cookingTime(10)
                 .build();
-        this.target = TestHasCookingTimeBuilder.builder()
+        this.target = HasCookingTimeTestBuilder.builder()
                 .cookingTime(20)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedImageMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedImageMapperIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasImageBuilder;
+import com.askie01.recipeapplication.builder.HasImageTestBuilder;
 import com.askie01.recipeapplication.configuration.FiveMegaBytesImageValidatorConfiguration;
 import com.askie01.recipeapplication.configuration.ValidatedImageMapperConfiguration;
 import com.askie01.recipeapplication.mapper.ImageMapper;
@@ -39,10 +39,10 @@ class ValidatedImageMapperIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        this.source = TestHasImageBuilder.builder()
+        this.source = HasImageTestBuilder.builder()
                 .image(new byte[1024])
                 .build();
-        this.target = TestHasImageBuilder.builder()
+        this.target = HasImageTestBuilder.builder()
                 .image(new byte[2 * 1024])
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedInstructionsMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedInstructionsMapperIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasInstructionsBuilder;
+import com.askie01.recipeapplication.builder.HasInstructionsTestBuilder;
 import com.askie01.recipeapplication.configuration.NonBlankInstructionsValidatorConfiguration;
 import com.askie01.recipeapplication.configuration.ValidatedInstructionsMapperConfiguration;
 import com.askie01.recipeapplication.mapper.InstructionsMapper;
@@ -43,10 +43,10 @@ class ValidatedInstructionsMapperIntegrationTest {
         final Faker faker = new Faker();
         final String sourceInstructions = faker.lorem().paragraph();
         final String targetInstructions = faker.lorem().paragraph();
-        this.source = TestHasInstructionsBuilder.builder()
+        this.source = HasInstructionsTestBuilder.builder()
                 .instructions(sourceInstructions)
                 .build();
-        this.target = TestHasInstructionsBuilder.builder()
+        this.target = HasInstructionsTestBuilder.builder()
                 .instructions(targetInstructions)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedLongIdMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedLongIdMapperIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasLongIdBuilder;
+import com.askie01.recipeapplication.builder.HasLongIdTestBuilder;
 import com.askie01.recipeapplication.configuration.PositiveLongIdValidatorConfiguration;
 import com.askie01.recipeapplication.configuration.ValidatedLongIdMapperConfiguration;
 import com.askie01.recipeapplication.mapper.LongIdMapper;
@@ -39,10 +39,10 @@ class ValidatedLongIdMapperIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        this.source = TestHasLongIdBuilder.builder()
+        this.source = HasLongIdTestBuilder.builder()
                 .id(1L)
                 .build();
-        this.target = TestHasLongIdBuilder.builder()
+        this.target = HasLongIdTestBuilder.builder()
                 .id(2L)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedLongVersionMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedLongVersionMapperIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasLongVersionBuilder;
+import com.askie01.recipeapplication.builder.HasLongVersionTestBuilder;
 import com.askie01.recipeapplication.configuration.PositiveLongVersionValidatorConfiguration;
 import com.askie01.recipeapplication.configuration.ValidatedLongVersionMapperConfiguration;
 import com.askie01.recipeapplication.mapper.LongVersionMapper;
@@ -39,10 +39,10 @@ class ValidatedLongVersionMapperIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        this.source = TestHasLongVersionBuilder.builder()
+        this.source = HasLongVersionTestBuilder.builder()
                 .version(1L)
                 .build();
-        this.target = TestHasLongVersionBuilder.builder()
+        this.target = HasLongVersionTestBuilder.builder()
                 .version(5L)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedServingsMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedServingsMapperIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasServingsBuilder;
+import com.askie01.recipeapplication.builder.HasServingsTestBuilder;
 import com.askie01.recipeapplication.configuration.PositiveServingsValidatorConfiguration;
 import com.askie01.recipeapplication.configuration.ValidatedServingsMapperConfiguration;
 import com.askie01.recipeapplication.mapper.ServingsMapper;
@@ -39,10 +39,10 @@ class ValidatedServingsMapperIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        this.source = TestHasServingsBuilder.builder()
+        this.source = HasServingsTestBuilder.builder()
                 .servings(1.0)
                 .build();
-        this.target = TestHasServingsBuilder.builder()
+        this.target = HasServingsTestBuilder.builder()
                 .servings(5.0)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedStringNameMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/ValidatedStringNameMapperIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasStringNameBuilder;
+import com.askie01.recipeapplication.builder.HasStringNameTestBuilder;
 import com.askie01.recipeapplication.configuration.NonBlankStringNameValidatorConfiguration;
 import com.askie01.recipeapplication.configuration.ValidatedStringNameMapperConfiguration;
 import com.askie01.recipeapplication.mapper.StringNameMapper;
@@ -41,10 +41,10 @@ class ValidatedStringNameMapperIntegrationTest {
     @BeforeEach
     void setUp() {
         final Faker faker = new Faker();
-        this.source = TestHasStringNameBuilder.builder()
+        this.source = HasStringNameTestBuilder.builder()
                 .name(faker.funnyName().name())
                 .build();
-        this.target = TestHasStringNameBuilder.builder()
+        this.target = HasStringNameTestBuilder.builder()
                 .name(faker.funnyName().name())
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/integration/validator/FiveMegaBytesImageValidatorIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/validator/FiveMegaBytesImageValidatorIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.validator;
 
-import com.askie01.recipeapplication.builder.TestHasImageBuilder;
+import com.askie01.recipeapplication.builder.HasImageTestBuilder;
 import com.askie01.recipeapplication.configuration.FiveMegaBytesImageValidatorConfiguration;
 import com.askie01.recipeapplication.model.value.HasImage;
 import com.askie01.recipeapplication.validator.ImageValidator;
@@ -32,7 +32,7 @@ class FiveMegaBytesImageValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return true when image size is above 0 MBs")
     void isValid_whenImageSizeIsAboveZeroMegaBytes_returnsTrue() {
-        final HasImage argument = TestHasImageBuilder.builder()
+        final HasImage argument = HasImageTestBuilder.builder()
                 .image(new byte[2 * 1024 * 1024])
                 .build();
         final boolean result = validator.isValid(argument);
@@ -42,7 +42,7 @@ class FiveMegaBytesImageValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return true when image size is exactly 5 MBs")
     void isValid_whenImageSizeIsExactlyFiveMegaBytes_returnsTrue() {
-        final HasImage argument = TestHasImageBuilder.builder()
+        final HasImage argument = HasImageTestBuilder.builder()
                 .image(new byte[5 * 1024 * 1024])
                 .build();
         final boolean result = validator.isValid(argument);
@@ -52,7 +52,7 @@ class FiveMegaBytesImageValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return true when image size is 0 Bytes")
     void isValid_whenImageSizeIsZeroBytes_returnsTrue() {
-        final HasImage argument = TestHasImageBuilder.builder()
+        final HasImage argument = HasImageTestBuilder.builder()
                 .image(new byte[0])
                 .build();
         final boolean result = validator.isValid(argument);
@@ -62,7 +62,7 @@ class FiveMegaBytesImageValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if image in HasImage is null")
     void isValid_whenImageIsNull_throwsNullPointerException() {
-        final HasImage argument = TestHasImageBuilder.builder()
+        final HasImage argument = HasImageTestBuilder.builder()
                 .image(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/integration/validator/NonBlankInstructionsValidatorIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/validator/NonBlankInstructionsValidatorIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.validator;
 
-import com.askie01.recipeapplication.builder.TestHasInstructionsBuilder;
+import com.askie01.recipeapplication.builder.HasInstructionsTestBuilder;
 import com.askie01.recipeapplication.configuration.NonBlankInstructionsValidatorConfiguration;
 import com.askie01.recipeapplication.model.value.HasInstructions;
 import com.askie01.recipeapplication.validator.InstructionsValidator;
@@ -33,7 +33,7 @@ class NonBlankInstructionsValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return true when source instructions is non-blank")
     void isValid_whenSourceInstructionsIsNonBlank_returnsTrue() {
-        final HasInstructions argument = TestHasInstructionsBuilder.builder()
+        final HasInstructions argument = HasInstructionsTestBuilder.builder()
                 .instructions("instructions")
                 .build();
         final boolean result = validator.isValid(argument);
@@ -43,7 +43,7 @@ class NonBlankInstructionsValidatorIntegrationTest {
     @ParameterizedTest(name = "isValid method should return false when source instructions is blank")
     @ValueSource(strings = {"", "   "})
     void isValid_whenSourceInstructionsIsBlank_returnsFalse(String instructions) {
-        final HasInstructions argument = TestHasInstructionsBuilder.builder()
+        final HasInstructions argument = HasInstructionsTestBuilder.builder()
                 .instructions(instructions)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -53,7 +53,7 @@ class NonBlankInstructionsValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if source instructions is null")
     void isValid_whenSourceHasNullInstructions_throwsNullPointerException() {
-        final HasInstructions argument = TestHasInstructionsBuilder.builder()
+        final HasInstructions argument = HasInstructionsTestBuilder.builder()
                 .instructions(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/integration/validator/NonBlankStringNameValidatorIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/validator/NonBlankStringNameValidatorIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.validator;
 
-import com.askie01.recipeapplication.builder.TestHasStringNameBuilder;
+import com.askie01.recipeapplication.builder.HasStringNameTestBuilder;
 import com.askie01.recipeapplication.configuration.NonBlankStringNameValidatorConfiguration;
 import com.askie01.recipeapplication.model.value.HasStringName;
 import com.askie01.recipeapplication.validator.StringNameValidator;
@@ -33,7 +33,7 @@ class NonBlankStringNameValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return true when name is non-blank")
     void isValid_whenNameIsNonBlank_returnsTrue() {
-        final HasStringName argument = TestHasStringNameBuilder.builder()
+        final HasStringName argument = HasStringNameTestBuilder.builder()
                 .name("name")
                 .build();
         final boolean result = validator.isValid(argument);
@@ -43,7 +43,7 @@ class NonBlankStringNameValidatorIntegrationTest {
     @ParameterizedTest(name = "isValid method should return false when name is blank")
     @ValueSource(strings = {"", "   "})
     void isValid_whenNameIsBlank_returnsFalse(String name) {
-        final HasStringName argument = TestHasStringNameBuilder.builder()
+        final HasStringName argument = HasStringNameTestBuilder.builder()
                 .name(name)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -53,7 +53,7 @@ class NonBlankStringNameValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if name in HasStringName is null")
     void isValid_whenNameIsNull_throwsNullPointerException() {
-        final HasStringName argument = TestHasStringNameBuilder.builder()
+        final HasStringName argument = HasStringNameTestBuilder.builder()
                 .name(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/integration/validator/PositiveCookingTimeValidatorIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/validator/PositiveCookingTimeValidatorIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.validator;
 
-import com.askie01.recipeapplication.builder.TestHasCookingTimeBuilder;
+import com.askie01.recipeapplication.builder.HasCookingTimeTestBuilder;
 import com.askie01.recipeapplication.configuration.PositiveCookingTimeValidatorConfiguration;
 import com.askie01.recipeapplication.model.value.HasCookingTime;
 import com.askie01.recipeapplication.validator.CookingTimeValidator;
@@ -31,7 +31,7 @@ class PositiveCookingTimeValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return true when source cooking time is positive")
     void isValid_whenSourceCookingTimeIsPositive_returnsTrue() {
-        final HasCookingTime argument = TestHasCookingTimeBuilder.builder()
+        final HasCookingTime argument = HasCookingTimeTestBuilder.builder()
                 .cookingTime(5)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -41,7 +41,7 @@ class PositiveCookingTimeValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return false when source cooking time is negative")
     void isValid_whenSourceCookingTimeIsNegative_returnsFalse() {
-        final HasCookingTime argument = TestHasCookingTimeBuilder.builder()
+        final HasCookingTime argument = HasCookingTimeTestBuilder.builder()
                 .cookingTime(-5)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -51,7 +51,7 @@ class PositiveCookingTimeValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if source cooking time is null")
     void isValid_whenSourceCookingTimeIsNull_throwsNullPointerException() {
-        final HasCookingTime argument = TestHasCookingTimeBuilder.builder()
+        final HasCookingTime argument = HasCookingTimeTestBuilder.builder()
                 .cookingTime(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/integration/validator/PositiveLongIdValidatorIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/validator/PositiveLongIdValidatorIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.validator;
 
-import com.askie01.recipeapplication.builder.TestHasLongIdBuilder;
+import com.askie01.recipeapplication.builder.HasLongIdTestBuilder;
 import com.askie01.recipeapplication.configuration.PositiveLongIdValidatorConfiguration;
 import com.askie01.recipeapplication.model.value.HasLongId;
 import com.askie01.recipeapplication.validator.LongIdValidator;
@@ -31,7 +31,7 @@ class PositiveLongIdValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return true when id in HasLongId is positive")
     void isValid_whenIdIsPositive_returnsTrue() {
-        final HasLongId argument = TestHasLongIdBuilder.builder()
+        final HasLongId argument = HasLongIdTestBuilder.builder()
                 .id(1L)
                 .build();
         final boolean actualResult = validator.isValid(argument);
@@ -41,7 +41,7 @@ class PositiveLongIdValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return false when id in HasLongId is negative")
     void isValid_whenIdIsNegative_returnsFalse() {
-        final HasLongId argument = TestHasLongIdBuilder.builder()
+        final HasLongId argument = HasLongIdTestBuilder.builder()
                 .id(-1L)
                 .build();
         final boolean actualResult = validator.isValid(argument);
@@ -51,7 +51,7 @@ class PositiveLongIdValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if id in HasLongId is null")
     void isValid_whenIdIsNull_throwsNullPointerException() {
-        final HasLongId argument = TestHasLongIdBuilder.builder()
+        final HasLongId argument = HasLongIdTestBuilder.builder()
                 .id(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/integration/validator/PositiveLongVersionValidatorIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/validator/PositiveLongVersionValidatorIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.validator;
 
-import com.askie01.recipeapplication.builder.TestHasLongVersionBuilder;
+import com.askie01.recipeapplication.builder.HasLongVersionTestBuilder;
 import com.askie01.recipeapplication.configuration.PositiveLongVersionValidatorConfiguration;
 import com.askie01.recipeapplication.model.value.HasLongVersion;
 import com.askie01.recipeapplication.validator.LongVersionValidator;
@@ -31,7 +31,7 @@ class PositiveLongVersionValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return true when source version is positive")
     void isValid_whenSourceVersionIsPositive_returnsTrue() {
-        final HasLongVersion argument = TestHasLongVersionBuilder.builder()
+        final HasLongVersion argument = HasLongVersionTestBuilder.builder()
                 .version(5L)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -41,7 +41,7 @@ class PositiveLongVersionValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return false when source version is negative")
     void isValid_whenSourceVersionIsNegative_returnsFalse() {
-        final HasLongVersion argument = TestHasLongVersionBuilder.builder()
+        final HasLongVersion argument = HasLongVersionTestBuilder.builder()
                 .version(-5L)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -51,7 +51,7 @@ class PositiveLongVersionValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if source version is null")
     void isValid_whenSourceVersionIsNull_throwsNullPointerException() {
-        final HasLongVersion argument = TestHasLongVersionBuilder.builder()
+        final HasLongVersion argument = HasLongVersionTestBuilder.builder()
                 .version(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/integration/validator/PositiveServingsValidatorIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/validator/PositiveServingsValidatorIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.integration.validator;
 
-import com.askie01.recipeapplication.builder.TestHasServingsBuilder;
+import com.askie01.recipeapplication.builder.HasServingsTestBuilder;
 import com.askie01.recipeapplication.configuration.PositiveServingsValidatorConfiguration;
 import com.askie01.recipeapplication.model.value.HasServings;
 import com.askie01.recipeapplication.validator.ServingsValidator;
@@ -31,7 +31,7 @@ class PositiveServingsValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return true when source servings is positive")
     void isValid_whenSourceServingsIsPositive_returnsTrue() {
-        final HasServings argument = TestHasServingsBuilder.builder()
+        final HasServings argument = HasServingsTestBuilder.builder()
                 .servings(5d)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -41,7 +41,7 @@ class PositiveServingsValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should return false when source servings is negative")
     void isValid_whenSourceServingsIsNegative_returnsFalse() {
-        final HasServings argument = TestHasServingsBuilder.builder()
+        final HasServings argument = HasServingsTestBuilder.builder()
                 .servings(-5d)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -51,7 +51,7 @@ class PositiveServingsValidatorIntegrationTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if source servings is null")
     void isValid_whenSourceServingsIsNull_throwsNullPointerException() {
-        final HasServings argument = TestHasServingsBuilder.builder()
+        final HasServings argument = HasServingsTestBuilder.builder()
                 .servings(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedCookingTimeMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedCookingTimeMapperUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasCookingTimeBuilder;
+import com.askie01.recipeapplication.builder.HasCookingTimeTestBuilder;
 import com.askie01.recipeapplication.mapper.CookingTimeMapper;
 import com.askie01.recipeapplication.mapper.ValidatedCookingTimeMapper;
 import com.askie01.recipeapplication.model.value.HasCookingTime;
@@ -31,10 +31,10 @@ class ValidatedCookingTimeMapperUnitTest {
     @BeforeEach
     void setUp() {
         this.mapper = new ValidatedCookingTimeMapper(validator);
-        this.source = TestHasCookingTimeBuilder.builder()
+        this.source = HasCookingTimeTestBuilder.builder()
                 .cookingTime(10)
                 .build();
-        this.target = TestHasCookingTimeBuilder.builder()
+        this.target = HasCookingTimeTestBuilder.builder()
                 .cookingTime(20)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedImageMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedImageMapperUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasImageBuilder;
+import com.askie01.recipeapplication.builder.HasImageTestBuilder;
 import com.askie01.recipeapplication.mapper.ImageMapper;
 import com.askie01.recipeapplication.mapper.ValidatedImageMapper;
 import com.askie01.recipeapplication.model.value.HasImage;
@@ -31,10 +31,10 @@ class ValidatedImageMapperUnitTest {
     @BeforeEach
     void setUp() {
         this.mapper = new ValidatedImageMapper(imageValidator);
-        this.source = TestHasImageBuilder.builder()
+        this.source = HasImageTestBuilder.builder()
                 .image(new byte[1024])
                 .build();
-        this.target = TestHasImageBuilder.builder()
+        this.target = HasImageTestBuilder.builder()
                 .image(new byte[2 * 1024])
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedInstructionsMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedInstructionsMapperUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasInstructionsBuilder;
+import com.askie01.recipeapplication.builder.HasInstructionsTestBuilder;
 import com.askie01.recipeapplication.mapper.InstructionsMapper;
 import com.askie01.recipeapplication.mapper.ValidatedInstructionsMapper;
 import com.askie01.recipeapplication.model.value.HasInstructions;
@@ -35,10 +35,10 @@ class ValidatedInstructionsMapperUnitTest {
         final Faker faker = new Faker();
         final String sourceInstructions = faker.lorem().paragraph();
         final String targetInstructions = faker.lorem().paragraph();
-        this.source = TestHasInstructionsBuilder.builder()
+        this.source = HasInstructionsTestBuilder.builder()
                 .instructions(sourceInstructions)
                 .build();
-        this.target = TestHasInstructionsBuilder.builder()
+        this.target = HasInstructionsTestBuilder.builder()
                 .instructions(targetInstructions)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedLongIdMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedLongIdMapperUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasLongIdBuilder;
+import com.askie01.recipeapplication.builder.HasLongIdTestBuilder;
 import com.askie01.recipeapplication.mapper.LongIdMapper;
 import com.askie01.recipeapplication.mapper.ValidatedLongIdMapper;
 import com.askie01.recipeapplication.model.value.HasLongId;
@@ -31,10 +31,10 @@ class ValidatedLongIdMapperUnitTest {
     @BeforeEach
     void setUp() {
         this.mapper = new ValidatedLongIdMapper(longIdValidator);
-        this.source = TestHasLongIdBuilder.builder()
+        this.source = HasLongIdTestBuilder.builder()
                 .id(1L)
                 .build();
-        this.target = TestHasLongIdBuilder.builder()
+        this.target = HasLongIdTestBuilder.builder()
                 .id(2L)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedLongVersionMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedLongVersionMapperUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasLongVersionBuilder;
+import com.askie01.recipeapplication.builder.HasLongVersionTestBuilder;
 import com.askie01.recipeapplication.mapper.LongVersionMapper;
 import com.askie01.recipeapplication.mapper.ValidatedLongVersionMapper;
 import com.askie01.recipeapplication.model.value.HasLongVersion;
@@ -31,10 +31,10 @@ class ValidatedLongVersionMapperUnitTest {
     @BeforeEach
     void setUp() {
         this.mapper = new ValidatedLongVersionMapper(validator);
-        this.source = TestHasLongVersionBuilder.builder()
+        this.source = HasLongVersionTestBuilder.builder()
                 .version(1L)
                 .build();
-        this.target = TestHasLongVersionBuilder.builder()
+        this.target = HasLongVersionTestBuilder.builder()
                 .version(5L)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedServingsMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedServingsMapperUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasServingsBuilder;
+import com.askie01.recipeapplication.builder.HasServingsTestBuilder;
 import com.askie01.recipeapplication.mapper.ServingsMapper;
 import com.askie01.recipeapplication.mapper.ValidatedServingsMapper;
 import com.askie01.recipeapplication.model.value.HasServings;
@@ -31,10 +31,10 @@ class ValidatedServingsMapperUnitTest {
     @BeforeEach
     void setUp() {
         this.mapper = new ValidatedServingsMapper(validator);
-        this.source = TestHasServingsBuilder.builder()
+        this.source = HasServingsTestBuilder.builder()
                 .servings(1.0)
                 .build();
-        this.target = TestHasServingsBuilder.builder()
+        this.target = HasServingsTestBuilder.builder()
                 .servings(5.0)
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedStringNameMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/ValidatedStringNameMapperUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.mapper;
 
-import com.askie01.recipeapplication.builder.TestHasStringNameBuilder;
+import com.askie01.recipeapplication.builder.HasStringNameTestBuilder;
 import com.askie01.recipeapplication.mapper.StringNameMapper;
 import com.askie01.recipeapplication.mapper.ValidatedStringNameMapper;
 import com.askie01.recipeapplication.model.value.HasStringName;
@@ -34,10 +34,10 @@ class ValidatedStringNameMapperUnitTest {
         this.mapper = new ValidatedStringNameMapper(validator);
 
         final Faker faker = new Faker();
-        this.source = TestHasStringNameBuilder.builder()
+        this.source = HasStringNameTestBuilder.builder()
                 .name(faker.funnyName().name())
                 .build();
-        this.target = TestHasStringNameBuilder.builder()
+        this.target = HasStringNameTestBuilder.builder()
                 .name(faker.funnyName().name())
                 .build();
     }

--- a/src/test/java/com/askie01/recipeapplication/unit/validator/FiveMegaBytesImageValidatorUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/validator/FiveMegaBytesImageValidatorUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.validator;
 
-import com.askie01.recipeapplication.builder.TestHasImageBuilder;
+import com.askie01.recipeapplication.builder.HasImageTestBuilder;
 import com.askie01.recipeapplication.model.value.HasImage;
 import com.askie01.recipeapplication.validator.FiveMegaBytesImageValidator;
 import com.askie01.recipeapplication.validator.ImageValidator;
@@ -26,7 +26,7 @@ class FiveMegaBytesImageValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return true when image size is above 0 MBs")
     void isValid_whenImageSizeIsAboveZeroMegaBytes_returnsTrue() {
-        final HasImage argument = TestHasImageBuilder.builder()
+        final HasImage argument = HasImageTestBuilder.builder()
                 .image(new byte[2 * 1024 * 1024])
                 .build();
         final boolean result = validator.isValid(argument);
@@ -36,7 +36,7 @@ class FiveMegaBytesImageValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return true when image size is exactly 5 MBs")
     void isValid_whenImageSizeIsExactlyFiveMegaBytes_returnsTrue() {
-        final HasImage argument = TestHasImageBuilder.builder()
+        final HasImage argument = HasImageTestBuilder.builder()
                 .image(new byte[5 * 1024 * 1024])
                 .build();
         final boolean result = validator.isValid(argument);
@@ -46,7 +46,7 @@ class FiveMegaBytesImageValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return true when image size is 0 Bytes")
     void isValid_whenImageSizeIsZeroBytes_returnsTrue() {
-        final HasImage argument = TestHasImageBuilder.builder()
+        final HasImage argument = HasImageTestBuilder.builder()
                 .image(new byte[0])
                 .build();
         final boolean result = validator.isValid(argument);
@@ -56,7 +56,7 @@ class FiveMegaBytesImageValidatorUnitTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if image in HasImage is null")
     void isValid_whenImageIsNull_throwsNullPointerException() {
-        final HasImage argument = TestHasImageBuilder.builder()
+        final HasImage argument = HasImageTestBuilder.builder()
                 .image(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/unit/validator/NonBlankInstructionsValidatorUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/validator/NonBlankInstructionsValidatorUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.validator;
 
-import com.askie01.recipeapplication.builder.TestHasInstructionsBuilder;
+import com.askie01.recipeapplication.builder.HasInstructionsTestBuilder;
 import com.askie01.recipeapplication.model.value.HasInstructions;
 import com.askie01.recipeapplication.validator.InstructionsValidator;
 import com.askie01.recipeapplication.validator.NonBlankInstructionsValidator;
@@ -27,7 +27,7 @@ class NonBlankInstructionsValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return true when source instructions is non-blank")
     void isValid_whenSourceInstructionsIsNonBlank_returnsTrue() {
-        final HasInstructions argument = TestHasInstructionsBuilder.builder()
+        final HasInstructions argument = HasInstructionsTestBuilder.builder()
                 .instructions("instructions")
                 .build();
         final boolean result = validator.isValid(argument);
@@ -37,7 +37,7 @@ class NonBlankInstructionsValidatorUnitTest {
     @ParameterizedTest(name = "isValid method should return false when source instructions is blank")
     @ValueSource(strings = {"", "   "})
     void isValid_whenSourceInstructionsIsBlank_returnsFalse(String instructions) {
-        final HasInstructions argument = TestHasInstructionsBuilder.builder()
+        final HasInstructions argument = HasInstructionsTestBuilder.builder()
                 .instructions(instructions)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -47,7 +47,7 @@ class NonBlankInstructionsValidatorUnitTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if source instructions is null")
     void isValid_whenSourceHasNullInstructions_throwsNullPointerException() {
-        final HasInstructions argument = TestHasInstructionsBuilder.builder()
+        final HasInstructions argument = HasInstructionsTestBuilder.builder()
                 .instructions(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/unit/validator/NonBlankStringNameValidatorUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/validator/NonBlankStringNameValidatorUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.validator;
 
-import com.askie01.recipeapplication.builder.TestHasStringNameBuilder;
+import com.askie01.recipeapplication.builder.HasStringNameTestBuilder;
 import com.askie01.recipeapplication.model.value.HasStringName;
 import com.askie01.recipeapplication.validator.NonBlankStringNameValidator;
 import com.askie01.recipeapplication.validator.StringNameValidator;
@@ -27,7 +27,7 @@ class NonBlankStringNameValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return true when name is non-blank")
     void isValid_whenNameIsNonBlank_returnsTrue() {
-        final HasStringName argument = TestHasStringNameBuilder.builder()
+        final HasStringName argument = HasStringNameTestBuilder.builder()
                 .name("name")
                 .build();
         final boolean result = validator.isValid(argument);
@@ -37,7 +37,7 @@ class NonBlankStringNameValidatorUnitTest {
     @ParameterizedTest(name = "isValid method should return false when name is blank")
     @ValueSource(strings = {"", "   "})
     void isValid_whenNameIsBlank_returnsFalse(String name) {
-        final HasStringName argument = TestHasStringNameBuilder.builder()
+        final HasStringName argument = HasStringNameTestBuilder.builder()
                 .name(name)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -47,7 +47,7 @@ class NonBlankStringNameValidatorUnitTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if name in HasStringName is null")
     void isValid_whenNameIsNull_throwsNullPointerException() {
-        final HasStringName argument = TestHasStringNameBuilder.builder()
+        final HasStringName argument = HasStringNameTestBuilder.builder()
                 .name(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/unit/validator/PositiveCookingTimeValidatorUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/validator/PositiveCookingTimeValidatorUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.validator;
 
-import com.askie01.recipeapplication.builder.TestHasCookingTimeBuilder;
+import com.askie01.recipeapplication.builder.HasCookingTimeTestBuilder;
 import com.askie01.recipeapplication.model.value.HasCookingTime;
 import com.askie01.recipeapplication.validator.CookingTimeValidator;
 import com.askie01.recipeapplication.validator.PositiveCookingTimeValidator;
@@ -25,7 +25,7 @@ class PositiveCookingTimeValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return true when source cooking time is positive")
     void isValid_whenSourceCookingTimeIsPositive_returnsTrue() {
-        final HasCookingTime argument = TestHasCookingTimeBuilder.builder()
+        final HasCookingTime argument = HasCookingTimeTestBuilder.builder()
                 .cookingTime(5)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -35,7 +35,7 @@ class PositiveCookingTimeValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return false when source cooking time is negative")
     void isValid_whenSourceCookingTimeIsNegative_returnsFalse() {
-        final HasCookingTime argument = TestHasCookingTimeBuilder.builder()
+        final HasCookingTime argument = HasCookingTimeTestBuilder.builder()
                 .cookingTime(-5)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -45,7 +45,7 @@ class PositiveCookingTimeValidatorUnitTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if source cooking time is null")
     void isValid_whenSourceCookingTimeIsNull_throwsNullPointerException() {
-        final HasCookingTime argument = TestHasCookingTimeBuilder.builder()
+        final HasCookingTime argument = HasCookingTimeTestBuilder.builder()
                 .cookingTime(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/unit/validator/PositiveLongIdValidatorUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/validator/PositiveLongIdValidatorUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.validator;
 
-import com.askie01.recipeapplication.builder.TestHasLongIdBuilder;
+import com.askie01.recipeapplication.builder.HasLongIdTestBuilder;
 import com.askie01.recipeapplication.model.value.HasLongId;
 import com.askie01.recipeapplication.validator.LongIdValidator;
 import com.askie01.recipeapplication.validator.PositiveLongIdValidator;
@@ -25,7 +25,7 @@ class PositiveLongIdValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return true when id in HasLongId is positive")
     void isValid_whenIdIsPositive_returnsTrue() {
-        final HasLongId argument = TestHasLongIdBuilder.builder()
+        final HasLongId argument = HasLongIdTestBuilder.builder()
                 .id(1L)
                 .build();
         final boolean actualResult = validator.isValid(argument);
@@ -35,7 +35,7 @@ class PositiveLongIdValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return false when id in HasLongId is negative")
     void isValid_whenIdIsNegative_returnsFalse() {
-        final HasLongId argument = TestHasLongIdBuilder.builder()
+        final HasLongId argument = HasLongIdTestBuilder.builder()
                 .id(-1L)
                 .build();
         final boolean actualResult = validator.isValid(argument);
@@ -45,7 +45,7 @@ class PositiveLongIdValidatorUnitTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if id in HasLongId is null")
     void isValid_whenIdIsNull_throwsNullPointerException() {
-        final HasLongId argument = TestHasLongIdBuilder.builder()
+        final HasLongId argument = HasLongIdTestBuilder.builder()
                 .id(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/unit/validator/PositiveLongVersionValidatorUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/validator/PositiveLongVersionValidatorUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.validator;
 
-import com.askie01.recipeapplication.builder.TestHasLongVersionBuilder;
+import com.askie01.recipeapplication.builder.HasLongVersionTestBuilder;
 import com.askie01.recipeapplication.model.value.HasLongVersion;
 import com.askie01.recipeapplication.validator.LongVersionValidator;
 import com.askie01.recipeapplication.validator.PositiveLongVersionValidator;
@@ -25,7 +25,7 @@ class PositiveLongVersionValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return true when source version is positive")
     void isValid_whenSourceVersionIsPositive_returnsTrue() {
-        final HasLongVersion argument = TestHasLongVersionBuilder.builder()
+        final HasLongVersion argument = HasLongVersionTestBuilder.builder()
                 .version(5L)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -35,7 +35,7 @@ class PositiveLongVersionValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return false when source version is negative")
     void isValid_whenSourceVersionIsNegative_returnsFalse() {
-        final HasLongVersion argument = TestHasLongVersionBuilder.builder()
+        final HasLongVersion argument = HasLongVersionTestBuilder.builder()
                 .version(-5L)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -45,7 +45,7 @@ class PositiveLongVersionValidatorUnitTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if source version is null")
     void isValid_whenSourceVersionIsNull_throwsNullPointerException() {
-        final HasLongVersion argument = TestHasLongVersionBuilder.builder()
+        final HasLongVersion argument = HasLongVersionTestBuilder.builder()
                 .version(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));

--- a/src/test/java/com/askie01/recipeapplication/unit/validator/PositiveServingsValidatorUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/validator/PositiveServingsValidatorUnitTest.java
@@ -1,6 +1,6 @@
 package com.askie01.recipeapplication.unit.validator;
 
-import com.askie01.recipeapplication.builder.TestHasServingsBuilder;
+import com.askie01.recipeapplication.builder.HasServingsTestBuilder;
 import com.askie01.recipeapplication.model.value.HasServings;
 import com.askie01.recipeapplication.validator.PositiveServingsValidator;
 import com.askie01.recipeapplication.validator.ServingsValidator;
@@ -25,7 +25,7 @@ class PositiveServingsValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return true when source servings is positive")
     void isValid_whenSourceServingsIsPositive_returnsTrue() {
-        final HasServings argument = TestHasServingsBuilder.builder()
+        final HasServings argument = HasServingsTestBuilder.builder()
                 .servings(5d)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -35,7 +35,7 @@ class PositiveServingsValidatorUnitTest {
     @Test
     @DisplayName("isValid method should return false when source servings is negative")
     void isValid_whenSourceServingsIsNegative_returnsFalse() {
-        final HasServings argument = TestHasServingsBuilder.builder()
+        final HasServings argument = HasServingsTestBuilder.builder()
                 .servings(-5d)
                 .build();
         final boolean result = validator.isValid(argument);
@@ -45,7 +45,7 @@ class PositiveServingsValidatorUnitTest {
     @Test
     @DisplayName("isValid method should throw NullPointerException if source servings is null")
     void isValid_whenSourceServingsIsNull_throwsNullPointerException() {
-        final HasServings argument = TestHasServingsBuilder.builder()
+        final HasServings argument = HasServingsTestBuilder.builder()
                 .servings(null)
                 .build();
         assertThrows(NullPointerException.class, () -> validator.isValid(argument));


### PR DESCRIPTION
* Renamed all test builders to `[Type]TestBuilder` format to align with other test component names.
* This change affected some test classes, so we include those as well.
* This pull request closes #206