### PR TITLE
Create `CategoryTestFactory` interface - close #218

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/factory/CategoryTestFactory.java
+++ b/src/test/java/com/askie01/recipeapplication/factory/CategoryTestFactory.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.factory;
+
+import com.askie01.recipeapplication.model.entity.Category;
+
+public interface CategoryTestFactory {
+    Category createCategory();
+}


### PR DESCRIPTION
* Created a simple `CategoryTestFactory` interface with a method to create a `Category` object and return it.
* This pull request closes #218