### PR TITLE
Create `CategoryCategoryDTOTestComparator` interface - close #222

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/comparator/CategoryCategoryDTOTestComparator.java
+++ b/src/test/java/com/askie01/recipeapplication/comparator/CategoryCategoryDTOTestComparator.java
@@ -1,0 +1,8 @@
+package com.askie01.recipeapplication.comparator;
+
+import com.askie01.recipeapplication.dto.CategoryDTO;
+import com.askie01.recipeapplication.model.entity.Category;
+
+public interface CategoryCategoryDTOTestComparator extends TestComparator<Category, CategoryDTO> {
+
+}


### PR DESCRIPTION
* Created a simple `CategoryCategoryDTOTestComparator` interface to perform `compare` operation between `Category` and `CategoryDTO` objects.
* This pull request closes #222