### PR TITLE
Create `LongIdTestComparator` interface - close #229

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/comparator/LongIdTestComparator.java
+++ b/src/test/java/com/askie01/recipeapplication/comparator/LongIdTestComparator.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.comparator;
+
+import com.askie01.recipeapplication.model.value.HasLongId;
+
+public interface LongIdTestComparator extends TestComparator<HasLongId, HasLongId> {
+
+}


### PR DESCRIPTION
* Created `LongIdTestComparator` interface to perform a `compare` operation between two `HasLongId` type objects.
* This pull request closes #229