### PR TITLE
Create `StringNameTestComparator` interface - close #231

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/comparator/StringNameTestComparator.java
+++ b/src/test/java/com/askie01/recipeapplication/comparator/StringNameTestComparator.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.comparator;
+
+import com.askie01.recipeapplication.model.value.HasStringName;
+
+public interface StringNameTestComparator extends TestComparator<HasStringName, HasStringName> {
+
+}


### PR DESCRIPTION
* Created `StringNameTestComparator` interface to perform a `compare` operation between two `HasStringName` type objects.
* This pull request closes #231