### PR TITLE
Create `DescriptionMapper` interface - close #197

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/mapper/DescriptionMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DescriptionMapper.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.model.value.HasDescription;
+
+public interface DescriptionMapper extends Mapper<HasDescription, HasDescription> {
+
+}


### PR DESCRIPTION
* Created a simple `DescriptionMapper` interface to perform a `map` operation between two `HasDescription` type objects.
* This pull request closes #197