### PR TITLE
Create `ImageTestComparator` interface - close #286

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/comparator/ImageTestComparator.java
+++ b/src/test/java/com/askie01/recipeapplication/comparator/ImageTestComparator.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.comparator;
+
+import com.askie01.recipeapplication.model.value.HasImage;
+
+public interface ImageTestComparator extends TestComparator<HasImage, HasImage> {
+
+}


### PR DESCRIPTION
* Created a simple `ImageTestComparator` interface to perform a `compare` operation between two `HasImage` type objects.
* This pull request closes #286