### PR TITLE
Create `ServingsTestComparator` interface - close #290

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/comparator/ServingsTestComparator.java
+++ b/src/test/java/com/askie01/recipeapplication/comparator/ServingsTestComparator.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.comparator;
+
+import com.askie01.recipeapplication.model.value.HasServings;
+
+public interface ServingsTestComparator extends TestComparator<HasServings, HasServings> {
+
+}


### PR DESCRIPTION
* Created a simple `ServingsTestComparator` interface to perform a `compare` operation between two `HasServings` type objects.
* This pull request closes #290