### PR TITLE
Create `NameTestPresenceChecker` interface - close #341

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/checker/NameTestPresenceChecker.java
+++ b/src/test/java/com/askie01/recipeapplication/checker/NameTestPresenceChecker.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.checker;
+
+import com.askie01.recipeapplication.model.value.HasName;
+
+public interface NameTestPresenceChecker <Nameable extends HasName<?>> {
+    boolean hasName(Nameable nameable);
+}


### PR DESCRIPTION
* Created a simple `NameTestPresenceChecker` interface to perform `name` field checks on a given `Nameable` generic type object of type `HasName<?>`
* This pull request closes #341