### PR TITLE
Create `ServingsTestPresenceChecker` interface - close #345

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/checker/ServingsTestPresenceChecker.java
+++ b/src/test/java/com/askie01/recipeapplication/checker/ServingsTestPresenceChecker.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.checker;
+
+import com.askie01.recipeapplication.model.value.HasServings;
+
+public interface ServingsTestPresenceChecker {
+    boolean hasServings(HasServings hasServings);
+}


### PR DESCRIPTION
* Created a simple `ServingsTestPresenceChecker` interface to perform a check operation on a given `HasServings` object.
* This pull request closes #345