### PR TITLE
Create `VersionTestPresenceChecker` generic type interface - close #355

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/checker/VersionTestPresenceChecker.java
+++ b/src/test/java/com/askie01/recipeapplication/checker/VersionTestPresenceChecker.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.checker;
+
+import com.askie01.recipeapplication.model.value.HasVersion;
+
+public interface VersionTestPresenceChecker <Versionable extends HasVersion<?>> {
+    boolean hasVersion(Versionable versionable);
+}


### PR DESCRIPTION
* Created a generic type interface `VersionTestPresenceChecker` to perform version check on a given `Versionable` generic type object.
* `Versionable` generic type object must be of a kind `HasVersion` - regardless of the `version` type.
* This pull request closes #355