### PR TITLE
Create `CategoryTestPersistenceChecker` interface - close #360

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/checker/CategoryTestPersistenceChecker.java
+++ b/src/test/java/com/askie01/recipeapplication/checker/CategoryTestPersistenceChecker.java
@@ -1,0 +1,7 @@
+package com.askie01.recipeapplication.checker;
+
+import com.askie01.recipeapplication.model.entity.Category;
+
+public interface CategoryTestPersistenceChecker extends TestPersistenceChecker<Category> {
+
+}


### PR DESCRIPTION
* Created a simple `CategoryTestPersistenceChecker` interface to check whether a given `Category` object was created or updated (in persistence context).
* This pull request closes #360