### PR TITLE
Update image validation logic in `FiveMegaBytesImageValidator` to check for null images - close #422

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/validator/FiveMegaBytesImageValidator.java
+++ b/src/main/java/com/askie01/recipeapplication/validator/FiveMegaBytesImageValidator.java
@@ -12,7 +12,11 @@ public class FiveMegaBytesImageValidator implements ImageValidator {
     }
 
     private boolean hasImageSizeUpToFiveMegaBytes(HasImage hasImage) {
-        final int imageSize = hasImage.getImage().length;
-        return imageSize <= FIVE_MEGA_BYTES;
+        final boolean imageExists = hasImage.getImage() != null;
+        if (imageExists) {
+            final int imageSize = hasImage.getImage().length;
+            return imageSize <= FIVE_MEGA_BYTES;
+        }
+        return false;
     }
 }

--- a/src/test/java/com/askie01/recipeapplication/integration/validator/FiveMegaBytesImageValidatorIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/validator/FiveMegaBytesImageValidatorIntegrationTest.java
@@ -14,8 +14,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = FiveMegaBytesImageValidatorConfiguration.class)
@@ -58,12 +57,13 @@ class FiveMegaBytesImageValidatorIntegrationTest {
     }
 
     @Test
-    @DisplayName("isValid method should throw NullPointerException if argument's image is null")
+    @DisplayName("isValid method should return false if argument's image is null")
     void isValid_whenArgumentImageIsNull_throwsNullPointerException() {
         final HasImage argument = HasImageTestBuilder.builder()
                 .image(null)
                 .build();
-        assertThrows(NullPointerException.class, () -> validator.isValid(argument));
+        final boolean result = validator.isValid(argument);
+        assertFalse(result);
     }
 
     @Test

--- a/src/test/java/com/askie01/recipeapplication/unit/validator/FiveMegaBytesImageValidatorUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/validator/FiveMegaBytesImageValidatorUnitTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("FiveMegaBytesImageValidator unit tests")
 @EnabledIfSystemProperty(named = "test.type", matches = "unit")
@@ -54,12 +53,13 @@ class FiveMegaBytesImageValidatorUnitTest {
     }
 
     @Test
-    @DisplayName("isValid method should throw NullPointerException if argument's image is null")
-    void isValid_whenArgumentImageIsNull_throwsNullPointerException() {
+    @DisplayName("isValid method should return false if argument's image is null")
+    void isValid_whenArgumentImageIsNull_returnsFalse() {
         final HasImage argument = HasImageTestBuilder.builder()
                 .image(null)
                 .build();
-        assertThrows(NullPointerException.class, () -> validator.isValid(argument));
+        final boolean result = validator.isValid(argument);
+        assertFalse(result);
     }
 
     @Test


### PR DESCRIPTION
* Updated validation logic to check for null occurrences in `image` field in a given `HasImage` object.
* Updated unit & integration tests along with that change.
* This pull request closes #422