### PR TITLE
Fix invalid default-recipe.png path in `DefaultRecipeServiceV1` - close #424

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/service/DefaultRecipeServiceV1.java
+++ b/src/main/java/com/askie01/recipeapplication/service/DefaultRecipeServiceV1.java
@@ -7,9 +7,8 @@ import com.askie01.recipeapplication.model.entity.Recipe;
 import com.askie01.recipeapplication.repository.RecipeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.core.io.ClassPathResource;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -41,10 +40,9 @@ public class DefaultRecipeServiceV1 implements RecipeServiceV1 {
 
     @SneakyThrows
     public byte[] getDefaultImage() {
-        final File defaultImageFile = new File("src/main/resources/static/default-recipe.png");
-        try (final FileInputStream defaultImageStream = new FileInputStream(defaultImageFile)) {
-            return defaultImageStream.readAllBytes();
-        }
+        return new ClassPathResource("static/default-recipe.png")
+                .getInputStream()
+                .readAllBytes();
     }
 
     @Override


### PR DESCRIPTION
* Fixed the file path for default recipe image to make it work both locally & inside docker environment.
* This pull request closes #424