### PR TITLE
Remove `Test` prefix before `IntegrationTest` in `RecipeRestControllerV1LoggingAspecftIntegrationTest` & Disable it - close #430

### DIFF
--- a/src/test/java/com/askie01/recipeapplication/integration/aspect/RecipeRestControllerV1LoggingAspectIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/aspect/RecipeRestControllerV1LoggingAspectIntegrationTest.java
@@ -7,6 +7,7 @@ import com.askie01.recipeapplication.factory.RecipeDTOUnsavedEntityTestFactory;
 import com.askie01.recipeapplication.repository.RecipeRepository;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@Disabled("This test has been disabled, because the behaviour is different than expected when ran via maven wrapper command")
 @Transactional
 @SpringBootTest
 @AutoConfigureDataJpa
@@ -32,7 +34,7 @@ import static org.mockito.Mockito.*;
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
 @DisplayName("RecipeRestControllerLoggingAspect integration tests")
 @EnabledIfSystemProperty(named = "test.type", matches = "integration")
-class RecipeRestControllerV1LoggingAspectTestIntegrationTest {
+class RecipeRestControllerV1LoggingAspectIntegrationTest {
 
     private RecipeDTO source;
     private final RestTestClient restTestClient;


### PR DESCRIPTION
* Fixed small typo in the test class name.
* Disabled the test from integration tests workflow, as it causes issues when run via mvn command.
* This pull request closes #430