### PR TITLE
Fix `Build Docker image` step in `publish.yaml` - close #444

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,10 +49,13 @@ jobs:
 
       - name: Build Docker image
         run: |
+          REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
           docker build \
-           -t ghcr.io/${{ github.repository }}:${{ inputs.version }} \
-           -t ghcr.io/${{ github.repository }}:latest \
-           .
+            -t ghcr.io/$REPO_LOWER:${{ inputs.version }} \
+            -t ghcr.io/$REPO_LOWER:latest \
+            .
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Push Docker image
         run: |


### PR DESCRIPTION
* Fixed a small issue in a `publish.yaml` workflow on `Build Docker image` step where the repository name should be a lower case.
* This pull request closes #444