### PR TITLE
Remove index for H2 database

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,7 +6,7 @@ spring:
     name: recipe-application
 
   datasource:
-    url: jdbc:h2:mem:embedded-database;MODE=MySQL
+    url: jdbc:h2:mem:embedded-database
     username: root
     password: root
 

--- a/src/main/resources/schema/04-recipe-schema.sql
+++ b/src/main/resources/schema/04-recipe-schema.sql
@@ -14,6 +14,3 @@ CREATE TABLE recipe
     updated_by   VARCHAR(255) DEFAULT NULL,
     version      BIGINT                          NOT NULL
 );
-
-ALTER TABLE recipe
-    ADD INDEX index_recipe_name_description (name, description);


### PR DESCRIPTION
* Due to few integration tests failing - we need to remove index for `h2` database.
* Fixed issue with failing integration tests.
* Removed MySQL mode as it did nothing there.