### PR TITLE
506 create createcustomerrequestbodytocustomermapper

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/configuration/CreateCustomerRequestBodyToCustomerMapperConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/CreateCustomerRequestBodyToCustomerMapperConfiguration.java
@@ -1,0 +1,23 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.CreateCustomerRequestBodyToCustomerMapper;
+import com.askie01.recipeapplication.mapper.DefaultCreateCustomerRequestBodyToCustomerMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class CreateCustomerRequestBodyToCustomerMapperConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            name = "component.mapper.create-customer-request-body-to-customer",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public CreateCustomerRequestBodyToCustomerMapper defaultCreateCustomerRequestBodyToCustomerMapper() {
+        return new DefaultCreateCustomerRequestBodyToCustomerMapper();
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/dto/CreateCustomerRequestBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/CreateCustomerRequestBody.java
@@ -1,0 +1,40 @@
+package com.askie01.recipeapplication.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@EqualsAndHashCode
+public class CreateCustomerRequestBody {
+
+    @Size(min = 3, message = "Username must contain at least 3 characters.")
+    @NotBlank(message = "Username cannot be blank/null")
+    private String username;
+
+    @Size(min = 3, message = "Password must contain at least 3 characters.")
+    @NotBlank(message = "Password cannot be blank/null")
+    private String password;
+
+    @Size(min = 3, message = "First name must contain at least 3 characters.")
+    @NotBlank(message = "First name cannot be blank/null")
+    private String firstName;
+
+    @Size(min = 3, message = "Last name must contain at least 3 characters.")
+    @NotBlank(message = "Last name cannot be blank/null")
+    private String lastName;
+
+    @Email(message = "Email must be valid.")
+    @NotBlank(message = "Email cannot be blank/null")
+    private String email;
+
+    @Size(min = 9, message = "Mobile number must be at least 9 digits long.")
+    @NotBlank(message = "Mobile number cannot be blank/null")
+    private String mobileNumber;
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/CreateCustomerRequestBodyToCustomerMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/CreateCustomerRequestBodyToCustomerMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CreateCustomerRequestBody;
+import com.askie01.recipeapplication.model.entity.Customer;
+
+public interface CreateCustomerRequestBodyToCustomerMapper
+        extends Mapper<CreateCustomerRequestBody, Customer>,
+        ToEntityMapper<CreateCustomerRequestBody, Customer> {
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/DefaultCreateCustomerRequestBodyToCustomerMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DefaultCreateCustomerRequestBodyToCustomerMapper.java
@@ -1,0 +1,58 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CreateCustomerRequestBody;
+import com.askie01.recipeapplication.model.entity.Customer;
+
+import java.util.HashSet;
+
+public class DefaultCreateCustomerRequestBodyToCustomerMapper implements CreateCustomerRequestBodyToCustomerMapper {
+
+    @Override
+    public Customer mapToEntity(CreateCustomerRequestBody requestBody) {
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>())
+                .build();
+        map(requestBody, customer);
+        return customer;
+    }
+
+    @Override
+    public void map(CreateCustomerRequestBody requestBody, Customer customer) {
+        mapUsername(requestBody, customer);
+        mapPassword(requestBody, customer);
+        mapFirstName(requestBody, customer);
+        mapLastName(requestBody, customer);
+        mapEmail(requestBody, customer);
+        mapMobileNumber(requestBody, customer);
+    }
+
+    private void mapUsername(CreateCustomerRequestBody requestBody, Customer customer) {
+        final String username = requestBody.getUsername();
+        customer.setUsername(username);
+    }
+
+    private void mapPassword(CreateCustomerRequestBody requestBody, Customer customer) {
+        final String password = requestBody.getPassword();
+        customer.setPassword(password);
+    }
+
+    private void mapFirstName(CreateCustomerRequestBody requestBody, Customer customer) {
+        final String firstName = requestBody.getFirstName();
+        customer.setFirstName(firstName);
+    }
+
+    private void mapLastName(CreateCustomerRequestBody requestBody, Customer customer) {
+        final String lastName = requestBody.getLastName();
+        customer.setLastName(lastName);
+    }
+
+    private void mapEmail(CreateCustomerRequestBody requestBody, Customer customer) {
+        final String email = requestBody.getEmail();
+        customer.setEmail(email);
+    }
+
+    private void mapMobileNumber(CreateCustomerRequestBody requestBody, Customer customer) {
+        final String mobileNumber = requestBody.getMobileNumber();
+        customer.setMobileNumber(mobileNumber);
+    }
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -201,6 +201,12 @@
       "defaultValue": "default"
     },
     {
+      "name": "component.mapper.create-customer-request-body-to-customer",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'CreateCustomerRequestBodyToCustomer' mapper type.",
+      "defaultValue": "default"
+    },
+    {
       "name": "component.service.recipe",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'RecipeService' implementation.",

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultCreateCustomerRequestBodyToCustomerMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultCreateCustomerRequestBodyToCustomerMapperIntegrationTest.java
@@ -1,0 +1,133 @@
+package com.askie01.recipeapplication.integration.mapper;
+
+import com.askie01.recipeapplication.configuration.CreateCustomerRequestBodyToCustomerMapperConfiguration;
+import com.askie01.recipeapplication.dto.CreateCustomerRequestBody;
+import com.askie01.recipeapplication.mapper.CreateCustomerRequestBodyToCustomerMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringJUnitConfig(classes = CreateCustomerRequestBodyToCustomerMapperConfiguration.class)
+@TestPropertySource(properties = "component.mapper.create-customer-request-body-to-customer=default")
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultCreateCustomerRequestBodyToCustomerMapper integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultCreateCustomerRequestBodyToCustomerMapperIntegrationTest {
+
+    private CreateCustomerRequestBody source;
+    private Customer target;
+    private final CreateCustomerRequestBodyToCustomerMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestCreateCustomerRequestBody();
+        this.target = getTestCustomer();
+    }
+
+    private CreateCustomerRequestBody getTestCreateCustomerRequestBody() {
+        return CreateCustomerRequestBody.builder()
+                .username("user")
+                .password("{noop}user")
+                .firstName("simple")
+                .lastName("user")
+                .email("simple.user@gmail.com")
+                .mobileNumber("123456789")
+                .build();
+    }
+
+    private Customer getTestCustomer() {
+        return Customer.builder()
+                .username("admin")
+                .password("{noop}admin")
+                .firstName("main")
+                .lastName("admin")
+                .email("main.admin@gmail.com")
+                .mobileNumber("987654321")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsValid_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceUsername = source.getUsername();
+        final String targetUsername = target.getUsername();
+        assertEquals(sourceUsername, targetUsername);
+
+        final String sourcePassword = source.getPassword();
+        final String targetPassword = target.getPassword();
+        assertEquals(sourcePassword, targetPassword);
+
+        final String sourceFirstName = source.getFirstName();
+        final String targetFirstName = target.getFirstName();
+        assertEquals(sourceFirstName, targetFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String targetLastName = target.getLastName();
+        assertEquals(sourceLastName, targetLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String targetEmail = target.getEmail();
+        assertEquals(sourceEmail, targetEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String targetMobileNumber = target.getMobileNumber();
+        assertEquals(sourceMobileNumber, targetMobileNumber);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should map all common fields from source to new Customer and return it")
+    void mapToEntity_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerAndReturnIt() {
+        final Customer customer = mapper.mapToEntity(source);
+        final String sourceUsername = source.getUsername();
+        final String customerUsername = customer.getUsername();
+        assertEquals(sourceUsername, customerUsername);
+
+        final String sourcePassword = source.getPassword();
+        final String customerPassword = customer.getPassword();
+        assertEquals(sourcePassword, customerPassword);
+
+        final String sourceFirstName = source.getFirstName();
+        final String customerFirstName = customer.getFirstName();
+        assertEquals(sourceFirstName, customerFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String customerLastName = customer.getLastName();
+        assertEquals(sourceLastName, customerLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String customerEmail = customer.getEmail();
+        assertEquals(sourceEmail, customerEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String customerMobileNumber = customer.getMobileNumber();
+        assertEquals(sourceMobileNumber, customerMobileNumber);
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should throw NullPointerException when source is null")
+    void mapToEntity_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToEntity(null));
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultCreateCustomerRequestBodyToCustomerMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultCreateCustomerRequestBodyToCustomerMapperUnitTest.java
@@ -1,0 +1,127 @@
+package com.askie01.recipeapplication.unit.mapper;
+
+import com.askie01.recipeapplication.dto.CreateCustomerRequestBody;
+import com.askie01.recipeapplication.mapper.CreateCustomerRequestBodyToCustomerMapper;
+import com.askie01.recipeapplication.mapper.DefaultCreateCustomerRequestBodyToCustomerMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("DefaultCreateCustomerRequestBodyToCustomer unit tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "unit")
+class DefaultCreateCustomerRequestBodyToCustomerMapperUnitTest {
+
+    private CreateCustomerRequestBody source;
+    private Customer target;
+    private CreateCustomerRequestBodyToCustomerMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestCreateCustomerRequestBody();
+        this.target = getTestCustomer();
+        this.mapper = new DefaultCreateCustomerRequestBodyToCustomerMapper();
+    }
+
+    private CreateCustomerRequestBody getTestCreateCustomerRequestBody() {
+        return CreateCustomerRequestBody.builder()
+                .username("user")
+                .password("{noop}user")
+                .firstName("simple")
+                .lastName("user")
+                .email("simple.user@gmail.com")
+                .mobileNumber("123456789")
+                .build();
+    }
+
+    private Customer getTestCustomer() {
+        return Customer.builder()
+                .username("admin")
+                .password("{noop}admin")
+                .firstName("main")
+                .lastName("admin")
+                .email("main.admin@gmail.com")
+                .mobileNumber("987654321")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsValid_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceUsername = source.getUsername();
+        final String targetUsername = target.getUsername();
+        assertEquals(sourceUsername, targetUsername);
+
+        final String sourcePassword = source.getPassword();
+        final String targetPassword = target.getPassword();
+        assertEquals(sourcePassword, targetPassword);
+
+        final String sourceFirstName = source.getFirstName();
+        final String targetFirstName = target.getFirstName();
+        assertEquals(sourceFirstName, targetFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String targetLastName = target.getLastName();
+        assertEquals(sourceLastName, targetLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String targetEmail = target.getEmail();
+        assertEquals(sourceEmail, targetEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String targetMobileNumber = target.getMobileNumber();
+        assertEquals(sourceMobileNumber, targetMobileNumber);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should map all common fields from source to new Customer and return it")
+    void mapToEntity_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerAndReturnIt() {
+        final Customer customer = mapper.mapToEntity(source);
+        final String sourceUsername = source.getUsername();
+        final String customerUsername = customer.getUsername();
+        assertEquals(sourceUsername, customerUsername);
+
+        final String sourcePassword = source.getPassword();
+        final String customerPassword = customer.getPassword();
+        assertEquals(sourcePassword, customerPassword);
+
+        final String sourceFirstName = source.getFirstName();
+        final String customerFirstName = customer.getFirstName();
+        assertEquals(sourceFirstName, customerFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String customerLastName = customer.getLastName();
+        assertEquals(sourceLastName, customerLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String customerEmail = customer.getEmail();
+        assertEquals(sourceEmail, customerEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String customerMobileNumber = customer.getMobileNumber();
+        assertEquals(sourceMobileNumber, customerMobileNumber);
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should throw NullPointerException when source is null")
+    void mapToEntity_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToEntity(null));
+    }
+}


### PR DESCRIPTION
* Created interface to specify the contract for mapping data from `CreateCustomerRequestBody` object to `Customer` object.
* Created default implementation of the mentioned interface - called `DefaultCreateCustomerRequestBodyToCustomerMapper` with implementation for simple mapping.
* Created unit & integration tests to make sure this component works as expected in both isolated, and spring environment.
* Created configuration class to register all implementations of mentioned interface for easier bean wiring & configuration.
* Added `component.mapper.create-customer-request-body-to-customer` configuration key in `additional-spring-configuration-metadata.json` along with short description for easier bean wiring via `application.yaml` file.
* This pull request should close #506 