### PR TITLE
507 create updatecustomerdetailsrequestbodytocustomermapper

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/configuration/UpdateCustomerDetailsRequestBodyToCustomerMapperConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/UpdateCustomerDetailsRequestBodyToCustomerMapperConfiguration.java
@@ -1,0 +1,23 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.DefaultUpdateCustomerDetailsRequestBodyToCustomerMapper;
+import com.askie01.recipeapplication.mapper.UpdateCustomerDetailsRequestBodyToCustomerMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class UpdateCustomerDetailsRequestBodyToCustomerMapperConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            name = "component.mapper.update-customer-details-request-body-to-customer",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public UpdateCustomerDetailsRequestBodyToCustomerMapper defaultUpdateCustomerDetailsRequestBodyToCustomerMapper() {
+        return new DefaultUpdateCustomerDetailsRequestBodyToCustomerMapper();
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/dto/UpdateCustomerDetailsRequestBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/UpdateCustomerDetailsRequestBody.java
@@ -1,0 +1,32 @@
+package com.askie01.recipeapplication.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@EqualsAndHashCode
+public class UpdateCustomerDetailsRequestBody {
+
+    @Size(min = 3, message = "First name must contain at least 3 characters.")
+    @NotBlank(message = "First name cannot be blank/null")
+    private String firstName;
+
+    @Size(min = 3, message = "Last name must contain at least 3 characters.")
+    @NotBlank(message = "Last name cannot be blank/null")
+    private String lastName;
+
+    @Email(message = "Email must be valid.")
+    @NotBlank(message = "Email cannot be blank/null")
+    private String email;
+
+    @Size(min = 9, message = "Mobile number must be at least 9 digits long.")
+    @NotBlank(message = "Mobile number cannot be blank/null")
+    private String mobileNumber;
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/DefaultUpdateCustomerDetailsRequestBodyToCustomerMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DefaultUpdateCustomerDetailsRequestBodyToCustomerMapper.java
@@ -1,0 +1,46 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.UpdateCustomerDetailsRequestBody;
+import com.askie01.recipeapplication.model.entity.Customer;
+
+import java.util.HashSet;
+
+public class DefaultUpdateCustomerDetailsRequestBodyToCustomerMapper implements UpdateCustomerDetailsRequestBodyToCustomerMapper {
+
+    @Override
+    public Customer mapToEntity(UpdateCustomerDetailsRequestBody requestBody) {
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>())
+                .build();
+        map(requestBody, customer);
+        return customer;
+    }
+
+    @Override
+    public void map(UpdateCustomerDetailsRequestBody requestBody, Customer customer) {
+        mapFirstName(requestBody, customer);
+        mapLastName(requestBody, customer);
+        mapEmail(requestBody, customer);
+        mapMobileNumber(requestBody, customer);
+    }
+
+    private void mapFirstName(UpdateCustomerDetailsRequestBody requestBody, Customer customer) {
+        final String firstName = requestBody.getFirstName();
+        customer.setFirstName(firstName);
+    }
+
+    private void mapLastName(UpdateCustomerDetailsRequestBody requestBody, Customer customer) {
+        final String lastName = requestBody.getLastName();
+        customer.setLastName(lastName);
+    }
+
+    private void mapEmail(UpdateCustomerDetailsRequestBody requestBody, Customer customer) {
+        final String email = requestBody.getEmail();
+        customer.setEmail(email);
+    }
+
+    private void mapMobileNumber(UpdateCustomerDetailsRequestBody requestBody, Customer customer) {
+        final String mobileNumber = requestBody.getMobileNumber();
+        customer.setMobileNumber(mobileNumber);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/UpdateCustomerDetailsRequestBodyToCustomerMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/UpdateCustomerDetailsRequestBodyToCustomerMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.UpdateCustomerDetailsRequestBody;
+import com.askie01.recipeapplication.model.entity.Customer;
+
+public interface UpdateCustomerDetailsRequestBodyToCustomerMapper
+        extends Mapper<UpdateCustomerDetailsRequestBody, Customer>,
+        ToEntityMapper<UpdateCustomerDetailsRequestBody, Customer> {
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -207,6 +207,12 @@
       "defaultValue": "default"
     },
     {
+      "name": "component.mapper.update-customer-details-request-body-to-customer",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'UpdateCustomerDetailsRequestBodyToCustomer' mapper type.",
+      "defaultValue": "default"
+    },
+    {
       "name": "component.service.recipe",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'RecipeService' implementation.",

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultUpdateCustomerDetailsRequestBodyToCustomerMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultUpdateCustomerDetailsRequestBodyToCustomerMapperIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.askie01.recipeapplication.integration.mapper;
+
+import com.askie01.recipeapplication.configuration.UpdateCustomerDetailsRequestBodyToCustomerMapperConfiguration;
+import com.askie01.recipeapplication.dto.UpdateCustomerDetailsRequestBody;
+import com.askie01.recipeapplication.mapper.UpdateCustomerDetailsRequestBodyToCustomerMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringJUnitConfig(classes = UpdateCustomerDetailsRequestBodyToCustomerMapperConfiguration.class)
+@TestPropertySource(properties = "component.mapper.update-customer-details-request-body-to-customer=default")
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultUpdateCustomerDetailsRequestBodyToCustomerMapper integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultUpdateCustomerDetailsRequestBodyToCustomerMapperIntegrationTest {
+
+    private UpdateCustomerDetailsRequestBody source;
+    private Customer target;
+    private final UpdateCustomerDetailsRequestBodyToCustomerMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestUpdateCustomerDetailsRequestBody();
+        this.target = getTestCustomer();
+    }
+
+    private UpdateCustomerDetailsRequestBody getTestUpdateCustomerDetailsRequestBody() {
+        return UpdateCustomerDetailsRequestBody.builder()
+                .firstName("Test first name")
+                .lastName("Test last name")
+                .email("test@example.com")
+                .mobileNumber("1234567890")
+                .build();
+    }
+
+    private Customer getTestCustomer() {
+        return Customer.builder()
+                .username("admin")
+                .password("{noop}admin")
+                .firstName("main")
+                .lastName("admin")
+                .email("main.admin@gmail.com")
+                .mobileNumber("987654321")
+                .build();
+    }
+
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceFirstName = source.getFirstName();
+        final String targetFirstName = target.getFirstName();
+        assertEquals(sourceFirstName, targetFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String targetLastName = target.getLastName();
+        assertEquals(sourceLastName, targetLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String targetEmail = target.getEmail();
+        assertEquals(sourceEmail, targetEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String targetMobileNumber = target.getMobileNumber();
+        assertEquals(sourceMobileNumber, targetMobileNumber);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should map all common fields from source to new Customer and return it")
+    void mapToEntity_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerAndReturnIt() {
+        final Customer customer = mapper.mapToEntity(source);
+        final String sourceFirstName = source.getFirstName();
+        final String customerFirstName = customer.getFirstName();
+        assertEquals(sourceFirstName, customerFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String customerLastName = customer.getLastName();
+        assertEquals(sourceLastName, customerLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String customerEmail = customer.getEmail();
+        assertEquals(sourceEmail, customerEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String customerMobileNumber = customer.getMobileNumber();
+        assertEquals(sourceMobileNumber, customerMobileNumber);
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should throw NullPointerException when source is null")
+    void mapToEntity_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToEntity(null));
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultUpdateCustomerDetailsRequestBodyToCustomerMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultUpdateCustomerDetailsRequestBodyToCustomerMapperUnitTest.java
@@ -1,0 +1,109 @@
+package com.askie01.recipeapplication.unit.mapper;
+
+import com.askie01.recipeapplication.dto.UpdateCustomerDetailsRequestBody;
+import com.askie01.recipeapplication.mapper.DefaultUpdateCustomerDetailsRequestBodyToCustomerMapper;
+import com.askie01.recipeapplication.mapper.UpdateCustomerDetailsRequestBodyToCustomerMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("DefaultUpdateCustomerDetailsRequestBodyToCustomerMapper unit tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "unit")
+class DefaultUpdateCustomerDetailsRequestBodyToCustomerMapperUnitTest {
+
+    private UpdateCustomerDetailsRequestBody source;
+    private Customer target;
+    private UpdateCustomerDetailsRequestBodyToCustomerMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestUpdateCustomerDetailsRequestBody();
+        this.target = getTestCustomer();
+        this.mapper = new DefaultUpdateCustomerDetailsRequestBodyToCustomerMapper();
+    }
+
+    private UpdateCustomerDetailsRequestBody getTestUpdateCustomerDetailsRequestBody() {
+        return UpdateCustomerDetailsRequestBody.builder()
+                .firstName("Test first name")
+                .lastName("Test last name")
+                .email("test@example.com")
+                .mobileNumber("1234567890")
+                .build();
+    }
+
+    private Customer getTestCustomer() {
+        return Customer.builder()
+                .username("admin")
+                .password("{noop}admin")
+                .firstName("main")
+                .lastName("admin")
+                .email("main.admin@gmail.com")
+                .mobileNumber("987654321")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceFirstName = source.getFirstName();
+        final String targetFirstName = target.getFirstName();
+        assertEquals(sourceFirstName, targetFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String targetLastName = target.getLastName();
+        assertEquals(sourceLastName, targetLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String targetEmail = target.getEmail();
+        assertEquals(sourceEmail, targetEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String targetMobileNumber = target.getMobileNumber();
+        assertEquals(sourceMobileNumber, targetMobileNumber);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should map all common fields from source to new Customer and return it")
+    void mapToEntity_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerAndReturnIt() {
+        final Customer customer = mapper.mapToEntity(source);
+        final String sourceFirstName = source.getFirstName();
+        final String customerFirstName = customer.getFirstName();
+        assertEquals(sourceFirstName, customerFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String customerLastName = customer.getLastName();
+        assertEquals(sourceLastName, customerLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String customerEmail = customer.getEmail();
+        assertEquals(sourceEmail, customerEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String customerMobileNumber = customer.getMobileNumber();
+        assertEquals(sourceMobileNumber, customerMobileNumber);
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should throw NullPointerException when source is null")
+    void mapToEntity_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToEntity(null));
+    }
+}


### PR DESCRIPTION
* Created `UpdateCustomerDetailsRequestBodyToCustomerMapper` interface along with default implementation to perform simple data mapping from `UpdateCustomerDetailsRequestBody` object to `Customer` object.
* Created both unit & integration tests to make sure this component works as expected in an isolated environment, as well as in a spring ecosystem. 
* Created configuration class to manage all implementations of new interface - for easier bean wiring & configuration.
* Added `component.mapper.update-customer-details-request-body-to-customer` configuration key in `additional-spring-configuration-metadata.json` along with short description & default value for clarity and awareness.
* This pull request should close #507 