### PR TITLE
513 create customertocustomerdetailsresponsebodymapper

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/configuration/CustomerToCustomerDetailsResponseBodyMapperConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/CustomerToCustomerDetailsResponseBodyMapperConfiguration.java
@@ -1,0 +1,23 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.CustomerToCustomerDetailsResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.DefaultCustomerToCustomerDetailsResponseBodyMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class CustomerToCustomerDetailsResponseBodyMapperConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            name = "component.mapper.customer-to-customer-details-response-body",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public CustomerToCustomerDetailsResponseBodyMapper defaultCustomerToCustomerDetailsResponseBodyMapper() {
+        return new DefaultCustomerToCustomerDetailsResponseBodyMapper();
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/dto/CustomerDetailsResponseBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/CustomerDetailsResponseBody.java
@@ -1,0 +1,17 @@
+package com.askie01.recipeapplication.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@EqualsAndHashCode
+public class CustomerDetailsResponseBody {
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String mobileNumber;
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/CustomerToCustomerDetailsResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/CustomerToCustomerDetailsResponseBodyMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerDetailsResponseBody;
+import com.askie01.recipeapplication.model.entity.Customer;
+
+public interface CustomerToCustomerDetailsResponseBodyMapper
+        extends Mapper<Customer, CustomerDetailsResponseBody>,
+        ToDTOMapper<Customer, CustomerDetailsResponseBody> {
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/DefaultCustomerToCustomerDetailsResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DefaultCustomerToCustomerDetailsResponseBodyMapper.java
@@ -1,0 +1,42 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerDetailsResponseBody;
+import com.askie01.recipeapplication.model.entity.Customer;
+
+public class DefaultCustomerToCustomerDetailsResponseBodyMapper implements CustomerToCustomerDetailsResponseBodyMapper {
+
+    @Override
+    public CustomerDetailsResponseBody mapToDTO(Customer customer) {
+        final CustomerDetailsResponseBody customerDetailsResponseBody = new CustomerDetailsResponseBody();
+        map(customer, customerDetailsResponseBody);
+        return customerDetailsResponseBody;
+    }
+
+    @Override
+    public void map(Customer customer, CustomerDetailsResponseBody responseBody) {
+        mapFirstName(customer, responseBody);
+        mapLastName(customer, responseBody);
+        mapEmail(customer, responseBody);
+        mapMobileNumber(customer, responseBody);
+    }
+
+    private void mapFirstName(Customer customer, CustomerDetailsResponseBody responseBody) {
+        final String firstName = customer.getFirstName();
+        responseBody.setFirstName(firstName);
+    }
+
+    private void mapLastName(Customer customer, CustomerDetailsResponseBody responseBody) {
+        final String lastName = customer.getLastName();
+        responseBody.setLastName(lastName);
+    }
+
+    private void mapEmail(Customer customer, CustomerDetailsResponseBody responseBody) {
+        final String email = customer.getEmail();
+        responseBody.setEmail(email);
+    }
+
+    private void mapMobileNumber(Customer customer, CustomerDetailsResponseBody responseBody) {
+        final String mobileNumber = customer.getMobileNumber();
+        responseBody.setMobileNumber(mobileNumber);
+    }
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -213,6 +213,12 @@
       "defaultValue": "default"
     },
     {
+      "name": "component.mapper.customer-to-customer-details-response-body",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'CustomerToCustomerDetailsResponseBody' mapper type.",
+      "defaultValue": "default"
+    },
+    {
       "name": "component.service.recipe",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'RecipeService' implementation.",

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultCustomerToCustomerDetailsResponseBodyMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultCustomerToCustomerDetailsResponseBodyMapperIntegrationTest.java
@@ -1,0 +1,115 @@
+package com.askie01.recipeapplication.integration.mapper;
+
+import com.askie01.recipeapplication.configuration.CustomerToCustomerDetailsResponseBodyMapperConfiguration;
+import com.askie01.recipeapplication.dto.CustomerDetailsResponseBody;
+import com.askie01.recipeapplication.mapper.CustomerToCustomerDetailsResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringJUnitConfig(classes = CustomerToCustomerDetailsResponseBodyMapperConfiguration.class)
+@TestPropertySource(properties = "component.mapper.customer-to-customer-details-response-body=default")
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultCustomerToCustomerDetailsResponseBodyMapper integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultCustomerToCustomerDetailsResponseBodyMapperIntegrationTest {
+
+    private Customer source;
+    private CustomerDetailsResponseBody target;
+    private final CustomerToCustomerDetailsResponseBodyMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestCustomer();
+        this.target = getTestCustomerDetailsResponseBody();
+    }
+
+    private static Customer getTestCustomer() {
+        return Customer.builder()
+                .username("admin")
+                .password("{noop}admin")
+                .firstName("main")
+                .lastName("admin")
+                .email("main.admin@gmail.com")
+                .mobileNumber("987654321")
+                .build();
+    }
+
+    private static CustomerDetailsResponseBody getTestCustomerDetailsResponseBody() {
+        return CustomerDetailsResponseBody.builder()
+                .firstName("Customer first name")
+                .lastName("Customer last name")
+                .email("customer@example.com")
+                .mobileNumber("123456789")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceFirstName = source.getFirstName();
+        final String targetFirstName = target.getFirstName();
+        assertEquals(sourceFirstName, targetFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String targetLastName = target.getLastName();
+        assertEquals(sourceLastName, targetLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String targetEmail = target.getEmail();
+        assertEquals(sourceEmail, targetEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String targetMobileNumber = target.getMobileNumber();
+        assertEquals(sourceMobileNumber, targetMobileNumber);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new CustomerDetailsResponseBody and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerDetailsResponseBodyAndReturnIt() {
+        final CustomerDetailsResponseBody customerDetailsResponseBody = mapper.mapToDTO(source);
+        final String sourceFirstName = source.getFirstName();
+        final String customerDetailsResponseBodyFirstName = customerDetailsResponseBody.getFirstName();
+        assertEquals(sourceFirstName, customerDetailsResponseBodyFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String customerDetailsResponseBodyLastName = customerDetailsResponseBody.getLastName();
+        assertEquals(sourceLastName, customerDetailsResponseBodyLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String customerDetailsResponseBodyEmail = customerDetailsResponseBody.getEmail();
+        assertEquals(sourceEmail, customerDetailsResponseBodyEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String customerDetailsResponseBodyMobileNumber = customerDetailsResponseBody.getMobileNumber();
+        assertEquals(sourceMobileNumber, customerDetailsResponseBodyMobileNumber);
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultCustomerToCustomerDetailsResponseBodyMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultCustomerToCustomerDetailsResponseBodyMapperUnitTest.java
@@ -1,0 +1,109 @@
+package com.askie01.recipeapplication.unit.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerDetailsResponseBody;
+import com.askie01.recipeapplication.mapper.CustomerToCustomerDetailsResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.DefaultCustomerToCustomerDetailsResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("DefaultCustomerToCustomerDetailsResponseBodyMapper unit tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "unit")
+class DefaultCustomerToCustomerDetailsResponseBodyMapperUnitTest {
+
+    private Customer source;
+    private CustomerDetailsResponseBody target;
+    private CustomerToCustomerDetailsResponseBodyMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestCustomer();
+        this.target = getTestCustomerDetailsResponseBody();
+        this.mapper = new DefaultCustomerToCustomerDetailsResponseBodyMapper();
+    }
+
+    private static Customer getTestCustomer() {
+        return Customer.builder()
+                .username("admin")
+                .password("{noop}admin")
+                .firstName("main")
+                .lastName("admin")
+                .email("main.admin@gmail.com")
+                .mobileNumber("987654321")
+                .build();
+    }
+
+    private static CustomerDetailsResponseBody getTestCustomerDetailsResponseBody() {
+        return CustomerDetailsResponseBody.builder()
+                .firstName("Customer first name")
+                .lastName("Customer last name")
+                .email("customer@example.com")
+                .mobileNumber("123456789")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceFirstName = source.getFirstName();
+        final String targetFirstName = target.getFirstName();
+        assertEquals(sourceFirstName, targetFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String targetLastName = target.getLastName();
+        assertEquals(sourceLastName, targetLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String targetEmail = target.getEmail();
+        assertEquals(sourceEmail, targetEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String targetMobileNumber = target.getMobileNumber();
+        assertEquals(sourceMobileNumber, targetMobileNumber);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new CustomerDetailsResponseBody and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerDetailsResponseBodyAndReturnIt() {
+        final CustomerDetailsResponseBody customerDetailsResponseBody = mapper.mapToDTO(source);
+        final String sourceFirstName = source.getFirstName();
+        final String customerDetailsResponseBodyFirstName = customerDetailsResponseBody.getFirstName();
+        assertEquals(sourceFirstName, customerDetailsResponseBodyFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String customerDetailsResponseBodyLastName = customerDetailsResponseBody.getLastName();
+        assertEquals(sourceLastName, customerDetailsResponseBodyLastName);
+
+        final String sourceEmail = source.getEmail();
+        final String customerDetailsResponseBodyEmail = customerDetailsResponseBody.getEmail();
+        assertEquals(sourceEmail, customerDetailsResponseBodyEmail);
+
+        final String sourceMobileNumber = source.getMobileNumber();
+        final String customerDetailsResponseBodyMobileNumber = customerDetailsResponseBody.getMobileNumber();
+        assertEquals(sourceMobileNumber, customerDetailsResponseBodyMobileNumber);
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+}


### PR DESCRIPTION
* Created `CustomerDetailsResponseBody` - the DTO class to send customer's confidential data in a response. 
* Created interface for mapping `Customer` object data to the corresponding `CustomerDetailsResponseBody` object - called it `CustomerToCustomerDetailsResponseBodyMapper`
* Created default implementation of the new interface to perform simple data mapping logic.
* Created both unit & integration tests to make sure this component works as expected in both isolated & spring environments.
* Created configuration class to manage bean creation & configuration of all `CustomerToCustomerDetailsResponseBodyMapper` implementations via `application.yaml` properties.
* Added `component.mapper.customer-to-customer-details-response-body` configuration key in `additional-spring-configuration-metadata.json` file for easier bean wiring via `application.yaml` file.
*  This pull request should close #514 and #513 