### PR TITLE
515 create customertocustomerprofileresponsebodymapper

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/configuration/CustomerToCustomerProfileResponseBodyMapperConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/CustomerToCustomerProfileResponseBodyMapperConfiguration.java
@@ -1,0 +1,23 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.CustomerToCustomerProfileResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.DefaultCustomerToCustomerProfileResponseBodyMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class CustomerToCustomerProfileResponseBodyMapperConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            name = "component.mapper.customer-to-customer-profile-response-body",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public CustomerToCustomerProfileResponseBodyMapper defaultCustomerToCustomerProfileResponseBodyMapper() {
+        return new DefaultCustomerToCustomerProfileResponseBodyMapper();
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/dto/CustomerProfileResponseBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/CustomerProfileResponseBody.java
@@ -1,0 +1,16 @@
+package com.askie01.recipeapplication.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@EqualsAndHashCode
+public class CustomerProfileResponseBody {
+    private String username;
+    private String firstName;
+    private String lastName;
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/CustomerToCustomerProfileResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/CustomerToCustomerProfileResponseBodyMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerProfileResponseBody;
+import com.askie01.recipeapplication.model.entity.Customer;
+
+public interface CustomerToCustomerProfileResponseBodyMapper
+        extends Mapper<Customer, CustomerProfileResponseBody>,
+        ToDTOMapper<Customer, CustomerProfileResponseBody> {
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/DefaultCustomerToCustomerProfileResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DefaultCustomerToCustomerProfileResponseBodyMapper.java
@@ -1,0 +1,36 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerProfileResponseBody;
+import com.askie01.recipeapplication.model.entity.Customer;
+
+public class DefaultCustomerToCustomerProfileResponseBodyMapper implements CustomerToCustomerProfileResponseBodyMapper {
+
+    @Override
+    public CustomerProfileResponseBody mapToDTO(Customer customer) {
+        final CustomerProfileResponseBody responseBody = new CustomerProfileResponseBody();
+        map(customer, responseBody);
+        return responseBody;
+    }
+
+    @Override
+    public void map(Customer customer, CustomerProfileResponseBody responseBody) {
+        mapUsername(customer, responseBody);
+        mapFirstName(customer, responseBody);
+        mapLastName(customer, responseBody);
+    }
+
+    private void mapUsername(Customer customer, CustomerProfileResponseBody responseBody) {
+        final String username = customer.getUsername();
+        responseBody.setUsername(username);
+    }
+
+    private void mapFirstName(Customer customer, CustomerProfileResponseBody responseBody) {
+        final String firstName = customer.getFirstName();
+        responseBody.setFirstName(firstName);
+    }
+
+    private void mapLastName(Customer customer, CustomerProfileResponseBody responseBody) {
+        final String lastName = customer.getLastName();
+        responseBody.setLastName(lastName);
+    }
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -209,13 +209,19 @@
     {
       "name": "component.mapper.update-customer-details-request-body-to-customer",
       "type": "java.lang.String",
-      "description": "Property used to wire a correct 'UpdateCustomerDetailsRequestBodyToCustomer' mapper type.",
+      "description": "Property used óto wire a correct 'UpdateCustomerDetailsRequestBodyToCustomer' mapper type.",
       "defaultValue": "default"
     },
     {
       "name": "component.mapper.customer-to-customer-details-response-body",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'CustomerToCustomerDetailsResponseBody' mapper type.",
+      "defaultValue": "default"
+    },
+    {
+      "name": "component.mapper.customer-to-customer-profile-response-body",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'CustomerToCustomerProfileResponseBody' mapper type.",
       "defaultValue": "default"
     },
     {

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultCustomerToCustomerProfileResponseBodyMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultCustomerToCustomerProfileResponseBodyMapperIntegrationTest.java
@@ -1,0 +1,106 @@
+package com.askie01.recipeapplication.integration.mapper;
+
+import com.askie01.recipeapplication.configuration.CustomerToCustomerProfileResponseBodyMapperConfiguration;
+import com.askie01.recipeapplication.dto.CustomerProfileResponseBody;
+import com.askie01.recipeapplication.mapper.CustomerToCustomerProfileResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringJUnitConfig(classes = CustomerToCustomerProfileResponseBodyMapperConfiguration.class)
+@TestPropertySource(properties = "component.mapper.customer-to-customer-profile-response-body=default")
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultCustomerToCustomerProfileResponseBodyMapper integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultCustomerToCustomerProfileResponseBodyMapperIntegrationTest {
+
+    private Customer source;
+    private CustomerProfileResponseBody target;
+    private final CustomerToCustomerProfileResponseBodyMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestCustomer();
+        this.target = getTestCustomerProfileResponseBody();
+    }
+
+    private static Customer getTestCustomer() {
+        return Customer.builder()
+                .username("admin")
+                .password("{noop}admin")
+                .firstName("main")
+                .lastName("admin")
+                .email("main.admin@gmail.com")
+                .mobileNumber("987654321")
+                .build();
+    }
+
+    private static CustomerProfileResponseBody getTestCustomerProfileResponseBody() {
+        return CustomerProfileResponseBody.builder()
+                .username("Customer username")
+                .firstName("Customer first name")
+                .lastName("Customer last name")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceUsername = source.getUsername();
+        final String targetUsername = target.getUsername();
+        assertEquals(sourceUsername, targetUsername);
+
+        final String sourceFirstName = source.getFirstName();
+        final String targetFirstName = target.getFirstName();
+        assertEquals(sourceFirstName, targetFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String targetLastName = target.getLastName();
+        assertEquals(sourceLastName, targetLastName);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new CustomerProfileResponseBody and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerProfileResponseBodyAndReturnIt() {
+        final CustomerProfileResponseBody customerProfileResponseBody = mapper.mapToDTO(source);
+        final String sourceUsername = source.getUsername();
+        final String customerProfileResponseBodyUsername = customerProfileResponseBody.getUsername();
+        assertEquals(sourceUsername, customerProfileResponseBodyUsername);
+
+        final String sourceFirstName = source.getFirstName();
+        final String customerProfileResponseBodyFirstName = customerProfileResponseBody.getFirstName();
+        assertEquals(sourceFirstName, customerProfileResponseBodyFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String customerProfileResponseBodyLastName = customerProfileResponseBody.getLastName();
+        assertEquals(sourceLastName, customerProfileResponseBodyLastName);
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultCustomerToCustomerProfileResponseBodyMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultCustomerToCustomerProfileResponseBodyMapperUnitTest.java
@@ -1,0 +1,100 @@
+package com.askie01.recipeapplication.unit.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerProfileResponseBody;
+import com.askie01.recipeapplication.mapper.CustomerToCustomerProfileResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.DefaultCustomerToCustomerProfileResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("DefaultCustomerToCustomerProfileResponseBodyMapper unit tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "unit")
+class DefaultCustomerToCustomerProfileResponseBodyMapperUnitTest {
+
+    private Customer source;
+    private CustomerProfileResponseBody target;
+    private CustomerToCustomerProfileResponseBodyMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestCustomer();
+        this.target = getTestCustomerProfileResponseBody();
+        this.mapper = new DefaultCustomerToCustomerProfileResponseBodyMapper();
+    }
+
+    private static Customer getTestCustomer() {
+        return Customer.builder()
+                .username("admin")
+                .password("{noop}admin")
+                .firstName("main")
+                .lastName("admin")
+                .email("main.admin@gmail.com")
+                .mobileNumber("987654321")
+                .build();
+    }
+
+    private static CustomerProfileResponseBody getTestCustomerProfileResponseBody() {
+        return CustomerProfileResponseBody.builder()
+                .username("Customer username")
+                .firstName("Customer first name")
+                .lastName("Customer last name")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceUsername = source.getUsername();
+        final String targetUsername = target.getUsername();
+        assertEquals(sourceUsername, targetUsername);
+
+        final String sourceFirstName = source.getFirstName();
+        final String targetFirstName = target.getFirstName();
+        assertEquals(sourceFirstName, targetFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String targetLastName = target.getLastName();
+        assertEquals(sourceLastName, targetLastName);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new CustomerProfileResponseBody and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerProfileResponseBodyAndReturnIt() {
+        final CustomerProfileResponseBody customerProfileResponseBody = mapper.mapToDTO(source);
+        final String sourceUsername = source.getUsername();
+        final String customerProfileResponseBodyUsername = customerProfileResponseBody.getUsername();
+        assertEquals(sourceUsername, customerProfileResponseBodyUsername);
+
+        final String sourceFirstName = source.getFirstName();
+        final String customerProfileResponseBodyFirstName = customerProfileResponseBody.getFirstName();
+        assertEquals(sourceFirstName, customerProfileResponseBodyFirstName);
+
+        final String sourceLastName = source.getLastName();
+        final String customerProfileResponseBodyLastName = customerProfileResponseBody.getLastName();
+        assertEquals(sourceLastName, customerProfileResponseBodyLastName);
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+}


### PR DESCRIPTION
* Created `CustomerProfileResponseBody` - DTO class to store customer's public data in a response.
* Created `CustomerToCustomerProfileResponseBodyMapper` contract interface to specify common mapping behavior.
* Created default implementation of the new interface to perform simple `Customer` to `CustomerProfileResponseBody` object data mapping.
* Created both unit & integration tests to cover up the implemented logic & edge cases.
* Created configuration class to manage bean wiring & configuration.
* Added `component.mapper.customer-to-customer-profile-response-body` configuration key in `additional-spring-configuration-metadata.json` file with short description & default value to ease up the process of bean wiring via `application.yaml` file.
* This pull request should close #516 and #515 