### PR TITLE
542 create recipetocustomerreciperesponsebodymapper

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/configuration/RecipeToCustomerRecipeResponseBodyMapperConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/RecipeToCustomerRecipeResponseBodyMapperConfiguration.java
@@ -1,0 +1,23 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.DefaultRecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToCustomerRecipeResponseBodyMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class RecipeToCustomerRecipeResponseBodyMapperConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            name = "component.mapper.recipe-to-customer-recipe-response-body",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public RecipeToCustomerRecipeResponseBodyMapper defaultRecipeToCustomerRecipeResponseBodyMapper() {
+        return new DefaultRecipeToCustomerRecipeResponseBodyMapper();
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/dto/CustomerRecipeResponseBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/CustomerRecipeResponseBody.java
@@ -1,0 +1,25 @@
+package com.askie01.recipeapplication.dto;
+
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import lombok.*;
+
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@EqualsAndHashCode
+public class CustomerRecipeResponseBody {
+    private Long id;
+    private String name;
+    private String description;
+    private Difficulty difficulty;
+    private Set<String> categories;
+    private Set<IngredientResponseBody> ingredients;
+    private Double servings;
+    private Integer cookingTime;
+    private String instructions;
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapper.java
@@ -1,0 +1,90 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeResponseBody;
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DefaultRecipeToCustomerRecipeResponseBodyMapper implements RecipeToCustomerRecipeResponseBodyMapper {
+
+    @Override
+    public CustomerRecipeResponseBody mapToDTO(Recipe recipe) {
+        final CustomerRecipeResponseBody customerRecipeResponseBody = new CustomerRecipeResponseBody();
+        map(recipe, customerRecipeResponseBody);
+        return customerRecipeResponseBody;
+    }
+
+    @Override
+    public void map(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        mapId(recipe, responseBody);
+        mapName(recipe, responseBody);
+        mapDescription(recipe, responseBody);
+        mapDifficulty(recipe, responseBody);
+        mapCategories(recipe, responseBody);
+        mapIngredients(recipe, responseBody);
+        mapServings(recipe, responseBody);
+        mapCookingTime(recipe, responseBody);
+        mapInstructions(recipe, responseBody);
+    }
+
+    private void mapId(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Long id = recipe.getId();
+        responseBody.setId(id);
+    }
+
+    private void mapName(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final String name = recipe.getName();
+        responseBody.setName(name);
+    }
+
+    private void mapDifficulty(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Difficulty difficulty = recipe.getDifficulty();
+        responseBody.setDifficulty(difficulty);
+    }
+
+    private void mapCategories(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Set<String> categories = recipe.getCategories()
+                .stream()
+                .map(Category::getName)
+                .collect(Collectors.toCollection(HashSet::new));
+        responseBody.setCategories(categories);
+    }
+
+    private void mapIngredients(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Set<IngredientResponseBody> ingredients = recipe.getIngredients()
+                .stream()
+                .map(ingredient -> {
+                    final String name = ingredient.getName();
+                    final Double amount = ingredient.getAmount();
+                    final String unit = ingredient.getMeasureUnit().getName();
+                    return new IngredientResponseBody(name, amount, unit);
+                })
+                .collect(Collectors.toCollection(HashSet::new));
+        responseBody.setIngredients(ingredients);
+    }
+
+    private void mapServings(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Double servings = recipe.getServings();
+        responseBody.setServings(servings);
+    }
+
+    private void mapCookingTime(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Integer cookingTime = recipe.getCookingTime();
+        responseBody.setCookingTime(cookingTime);
+    }
+
+    private void mapDescription(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final String description = recipe.getDescription();
+        responseBody.setDescription(description);
+    }
+
+    private void mapInstructions(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final String instructions = recipe.getInstructions();
+        responseBody.setInstructions(instructions);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/RecipeToCustomerRecipeResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/RecipeToCustomerRecipeResponseBodyMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeResponseBody;
+import com.askie01.recipeapplication.model.entity.Recipe;
+
+public interface RecipeToCustomerRecipeResponseBodyMapper
+        extends Mapper<Recipe, CustomerRecipeResponseBody>,
+        ToDTOMapper<Recipe, CustomerRecipeResponseBody> {
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -237,6 +237,12 @@
       "defaultValue": "default"
     },
     {
+      "name": "component.mapper.recipe-to-customer-recipe-response-body",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'RecipeToCustomerRecipeResponseBody' mapper type.",
+      "defaultValue": "default"
+    },
+    {
       "name": "component.service.recipe",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'RecipeService' implementation.",

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapperIntegrationTest.java
@@ -1,0 +1,214 @@
+package com.askie01.recipeapplication.integration.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeResponseBody;
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.mapper.DefaultRecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringJUnitConfig(classes = DefaultRecipeToCustomerRecipeResponseBodyMapper.class)
+@TestPropertySource(properties = "component.mapper.recipe-to-customer-recipe-response-body=default")
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultRecipeToCustomerRecipeResponseBodyMapper integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultRecipeToCustomerRecipeResponseBodyMapperIntegrationTest {
+
+    private Recipe source;
+    private CustomerRecipeResponseBody target;
+    private final RecipeToCustomerRecipeResponseBodyMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestRecipe();
+        this.target = getTestCustomerRecipeResponseBody();
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(1L)
+                .name("Test category")
+                .version(1L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(1L)
+                .name("Test measure unit")
+                .version(1L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(1L)
+                .name("Test ingredient")
+                .amount(1.0)
+                .measureUnit(measureUnit)
+                .version(1L)
+                .build();
+        return Recipe.builder()
+                .id(1L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(1.0)
+                .cookingTime(10)
+                .instructions("Test instructions in Recipe")
+                .version(1L)
+                .build();
+    }
+
+    private static CustomerRecipeResponseBody getTestCustomerRecipeResponseBody() {
+        return CustomerRecipeResponseBody.builder()
+                .id(2L)
+                .name("Test customer recipe")
+                .description("Test customer description")
+                .difficulty(Difficulty.MEDIUM)
+                .categories(new HashSet<>(Set.of("Test customer category")))
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientResponseBody("Test customer ingredient", 1.0, "Test customer unit")
+                )))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test customer instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        assertEquals(source.getId(), target.getId());
+        assertEquals(source.getName(), target.getName());
+        assertEquals(source.getDescription(), target.getDescription());
+        equalCategories(source, target);
+        equalIngredients(source, target);
+        assertEquals(source.getServings(), target.getServings());
+        assertEquals(source.getCookingTime(), target.getCookingTime());
+        assertEquals(source.getInstructions(), target.getInstructions());
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new CustomerRecipeResponseBody and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerRecipeResponseBodyAndReturnIt() {
+        final CustomerRecipeResponseBody customerRecipeResponseBody = mapper.mapToDTO(source);
+        final Long sourceId = source.getId();
+        final Long customerRecipeResponseBodyId = customerRecipeResponseBody.getId();
+        assertEquals(sourceId, customerRecipeResponseBodyId);
+
+        final String sourceName = source.getName();
+        final String customerRecipeResponseBodyName = customerRecipeResponseBody.getName();
+        assertEquals(sourceName, customerRecipeResponseBodyName);
+
+        final String sourceDescription = source.getDescription();
+        final String customerRecipeResponseBodyDescription = customerRecipeResponseBody.getDescription();
+        assertEquals(sourceDescription, customerRecipeResponseBodyDescription);
+
+        final Difficulty sourceDifficulty = source.getDifficulty();
+        final Difficulty customerRecipeResponseBodyDifficulty = customerRecipeResponseBody.getDifficulty();
+        assertEquals(sourceDifficulty, customerRecipeResponseBodyDifficulty);
+
+        equalCategories(source, customerRecipeResponseBody);
+        equalIngredients(source, customerRecipeResponseBody);
+
+        final Double sourceServings = source.getServings();
+        final Double customerRecipeResponseBodyServings = customerRecipeResponseBody.getServings();
+        assertEquals(sourceServings, customerRecipeResponseBodyServings);
+
+        final Integer sourceCookingTime = source.getCookingTime();
+        final Integer customerRecipeResponseBodyCookingTime = customerRecipeResponseBody.getCookingTime();
+        assertEquals(sourceCookingTime, customerRecipeResponseBodyCookingTime);
+
+        final String sourceInstructions = source.getInstructions();
+        final String customerRecipeResponseBodyInstructions = customerRecipeResponseBody.getInstructions();
+        assertEquals(sourceInstructions, customerRecipeResponseBodyInstructions);
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+
+    private static void equalCategories(Recipe source, CustomerRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getCategories()
+                        .stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList(),
+                target.getCategories()
+                        .stream()
+                        .sorted()
+                        .toList());
+    }
+
+    private static void equalIngredients(Recipe source, CustomerRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getUnit)
+                        .sorted()
+                        .toList()
+        );
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapperUnitTest.java
@@ -1,0 +1,208 @@
+package com.askie01.recipeapplication.unit.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeResponseBody;
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.mapper.DefaultRecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("DefaultRecipeToCustomerRecipeResponseBodyMapper unit tests")
+@EnabledIfSystemProperty(named = "test.unit", matches = "true")
+class DefaultRecipeToCustomerRecipeResponseBodyMapperUnitTest {
+
+    private Recipe source;
+    private CustomerRecipeResponseBody target;
+    private RecipeToCustomerRecipeResponseBodyMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestRecipe();
+        this.target = getTestCustomerRecipeResponseBody();
+        this.mapper = new DefaultRecipeToCustomerRecipeResponseBodyMapper();
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(1L)
+                .name("Test category")
+                .version(1L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(1L)
+                .name("Test measure unit")
+                .version(1L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(1L)
+                .name("Test ingredient")
+                .amount(1.0)
+                .measureUnit(measureUnit)
+                .version(1L)
+                .build();
+        return Recipe.builder()
+                .id(1L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(1.0)
+                .cookingTime(10)
+                .instructions("Test instructions in Recipe")
+                .version(1L)
+                .build();
+    }
+
+    private static CustomerRecipeResponseBody getTestCustomerRecipeResponseBody() {
+        return CustomerRecipeResponseBody.builder()
+                .id(2L)
+                .name("Test customer recipe")
+                .description("Test customer description")
+                .difficulty(Difficulty.MEDIUM)
+                .categories(new HashSet<>(Set.of("Test customer category")))
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientResponseBody("Test customer ingredient", 1.0, "Test customer unit")
+                )))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test customer instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        assertEquals(source.getId(), target.getId());
+        assertEquals(source.getName(), target.getName());
+        assertEquals(source.getDescription(), target.getDescription());
+        equalCategories(source, target);
+        equalIngredients(source, target);
+        assertEquals(source.getServings(), target.getServings());
+        assertEquals(source.getCookingTime(), target.getCookingTime());
+        assertEquals(source.getInstructions(), target.getInstructions());
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new CustomerRecipeResponseBody and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerRecipeResponseBodyAndReturnIt() {
+        final CustomerRecipeResponseBody customerRecipeResponseBody = mapper.mapToDTO(source);
+        final Long sourceId = source.getId();
+        final Long customerRecipeResponseBodyId = customerRecipeResponseBody.getId();
+        assertEquals(sourceId, customerRecipeResponseBodyId);
+
+        final String sourceName = source.getName();
+        final String customerRecipeResponseBodyName = customerRecipeResponseBody.getName();
+        assertEquals(sourceName, customerRecipeResponseBodyName);
+
+        final String sourceDescription = source.getDescription();
+        final String customerRecipeResponseBodyDescription = customerRecipeResponseBody.getDescription();
+        assertEquals(sourceDescription, customerRecipeResponseBodyDescription);
+
+        final Difficulty sourceDifficulty = source.getDifficulty();
+        final Difficulty customerRecipeResponseBodyDifficulty = customerRecipeResponseBody.getDifficulty();
+        assertEquals(sourceDifficulty, customerRecipeResponseBodyDifficulty);
+
+        equalCategories(source, customerRecipeResponseBody);
+        equalIngredients(source, customerRecipeResponseBody);
+
+        final Double sourceServings = source.getServings();
+        final Double customerRecipeResponseBodyServings = customerRecipeResponseBody.getServings();
+        assertEquals(sourceServings, customerRecipeResponseBodyServings);
+
+        final Integer sourceCookingTime = source.getCookingTime();
+        final Integer customerRecipeResponseBodyCookingTime = customerRecipeResponseBody.getCookingTime();
+        assertEquals(sourceCookingTime, customerRecipeResponseBodyCookingTime);
+
+        final String sourceInstructions = source.getInstructions();
+        final String customerRecipeResponseBodyInstructions = customerRecipeResponseBody.getInstructions();
+        assertEquals(sourceInstructions, customerRecipeResponseBodyInstructions);
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+
+    private static void equalCategories(Recipe source, CustomerRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getCategories()
+                        .stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList(),
+                target.getCategories()
+                        .stream()
+                        .sorted()
+                        .toList());
+    }
+
+    private static void equalIngredients(Recipe source, CustomerRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getUnit)
+                        .sorted()
+                        .toList()
+        );
+    }
+}


### PR DESCRIPTION
* Created mapper to perform `Recipe` object data mapping to the corresponding `CustomerRecipeResponseBody` object.
* Created both unit & integration tests to make sure this component works as expected in both isolated & spring environments.
* Created configuration class for all `RecipeToCustomerRecipeResponseBodyMapper` implementation for easier property-based bean management.
* Created new property to register our new component as a bean & mentioned it as a configuration key in `additional-spring-configuration-metadata.json` file for better understanding.
* This pull request should close #542 