### PR TITLE
541 create recipetosearchreciperesponsebodymapper

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/configuration/RecipeToSearchRecipeResponseBodyMapperConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/RecipeToSearchRecipeResponseBodyMapperConfiguration.java
@@ -1,0 +1,24 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.DefaultRecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class RecipeToSearchRecipeResponseBodyMapperConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            value = "component.mapper.recipe-to-search-recipe-response-body",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public RecipeToSearchRecipeResponseBodyMapper defaultRecipeToSearchRecipeResponseBodyMapper(RecipeRepositoryV3 recipeRepositoryV3) {
+        return new DefaultRecipeToSearchRecipeResponseBodyMapper(recipeRepositoryV3);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/dto/SearchRecipeResponseBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/SearchRecipeResponseBody.java
@@ -1,0 +1,26 @@
+package com.askie01.recipeapplication.dto;
+
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import lombok.*;
+
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@EqualsAndHashCode
+public class SearchRecipeResponseBody {
+    private String owner;
+    private Long id;
+    private String name;
+    private String description;
+    private Difficulty difficulty;
+    private Set<String> categories;
+    private Set<IngredientResponseBody> ingredients;
+    private Double servings;
+    private Integer cookingTime;
+    private String instructions;
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/DefaultRecipeToSearchRecipeResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DefaultRecipeToSearchRecipeResponseBodyMapper.java
@@ -1,0 +1,112 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.dto.SearchRecipeResponseBody;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class DefaultRecipeToSearchRecipeResponseBodyMapper implements RecipeToSearchRecipeResponseBodyMapper {
+
+    private final RecipeRepositoryV3 repository;
+
+    @Override
+    public SearchRecipeResponseBody mapToDTO(Recipe recipe) {
+        final SearchRecipeResponseBody searchRecipeResponseBody = new SearchRecipeResponseBody();
+        map(recipe, searchRecipeResponseBody);
+        return searchRecipeResponseBody;
+    }
+
+    @Override
+    public void map(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        mapId(recipe, searchRecipeResponseBody);
+        mapName(recipe, searchRecipeResponseBody);
+        mapDescription(recipe, searchRecipeResponseBody);
+        mapDifficulty(recipe, searchRecipeResponseBody);
+        mapCategories(recipe, searchRecipeResponseBody);
+        mapIngredients(recipe, searchRecipeResponseBody);
+        mapServings(recipe, searchRecipeResponseBody);
+        mapCookingTime(recipe, searchRecipeResponseBody);
+        mapInstructions(recipe, searchRecipeResponseBody);
+        mapOwner(recipe, searchRecipeResponseBody);
+    }
+
+    private void mapOwner(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Long recipeId = recipe.getId();
+        final String owner = repository
+                .findOwner(recipeId)
+                .orElseThrow(() -> new UsernameNotFoundException("Recipe with id: " + recipeId + " does not have owner"));
+        searchRecipeResponseBody.setOwner(owner);
+    }
+
+    private void mapId(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Long id = recipe.getId();
+        searchRecipeResponseBody.setId(id);
+    }
+
+    private void mapName(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final String name = recipe.getName();
+        searchRecipeResponseBody.setName(name);
+    }
+
+    private void mapDescription(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final String description = recipe.getDescription();
+        searchRecipeResponseBody.setDescription(description);
+    }
+
+    private void mapDifficulty(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Difficulty difficulty = recipe.getDifficulty();
+        searchRecipeResponseBody.setDifficulty(difficulty);
+    }
+
+    private void mapCategories(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Set<String> categories = recipe.getCategories()
+                .stream()
+                .map(Category::getName)
+                .collect(Collectors.toCollection(HashSet::new));
+        searchRecipeResponseBody.setCategories(categories);
+    }
+
+    private void mapIngredients(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Set<IngredientResponseBody> ingredients = recipe.getIngredients()
+                .stream()
+                .map(this::mapToIngredientResponseBody)
+                .collect(Collectors.toCollection(HashSet::new));
+        searchRecipeResponseBody.setIngredients(ingredients);
+    }
+
+    private IngredientResponseBody mapToIngredientResponseBody(Ingredient ingredient) {
+        final String name = ingredient.getName();
+        final Double amount = ingredient.getAmount();
+        final String unit = ingredient.getMeasureUnit().getName();
+        return IngredientResponseBody.builder()
+                .name(name)
+                .amount(amount)
+                .unit(unit)
+                .build();
+    }
+
+    private void mapServings(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Double servings = recipe.getServings();
+        searchRecipeResponseBody.setServings(servings);
+    }
+
+    private void mapCookingTime(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Integer cookingTime = recipe.getCookingTime();
+        searchRecipeResponseBody.setCookingTime(cookingTime);
+    }
+
+    private void mapInstructions(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final String instructions = recipe.getInstructions();
+        searchRecipeResponseBody.setInstructions(instructions);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/RecipeToSearchRecipeResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/RecipeToSearchRecipeResponseBodyMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.SearchRecipeResponseBody;
+import com.askie01.recipeapplication.model.entity.Recipe;
+
+public interface RecipeToSearchRecipeResponseBodyMapper
+        extends Mapper<Recipe, SearchRecipeResponseBody>,
+        ToDTOMapper<Recipe, SearchRecipeResponseBody> {
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -243,6 +243,12 @@
       "defaultValue": "default"
     },
     {
+      "name": "component.mapper.recipe-to-search-recipe-response-body",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'RecipeToSearchRecipeResponseBody' mapper type.",
+      "defaultValue": "default"
+    },
+    {
       "name": "component.service.recipe",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'RecipeService' implementation.",

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultRecipeToSearchRecipeResponseBodyMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultRecipeToSearchRecipeResponseBodyMapperIntegrationTest.java
@@ -1,0 +1,224 @@
+package com.askie01.recipeapplication.integration.mapper;
+
+import com.askie01.recipeapplication.configuration.JpaAuditingConfiguration;
+import com.askie01.recipeapplication.configuration.RecipeToSearchRecipeResponseBodyMapperConfiguration;
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.dto.SearchRecipeResponseBody;
+import com.askie01.recipeapplication.mapper.RecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Import(value = {
+        RecipeToSearchRecipeResponseBodyMapperConfiguration.class,
+        JpaAuditingConfiguration.class
+})
+@TestPropertySource(properties = {
+        "component.mapper.recipe-to-search-recipe-response-body=default",
+        "component.auditor-type=recipe-service-auditor"
+})
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultRecipeToSearchRecipeResponseBodyMapper integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultRecipeToSearchRecipeResponseBodyMapperIntegrationTest {
+
+    private Recipe source;
+    private SearchRecipeResponseBody target;
+    private final RecipeToSearchRecipeResponseBodyMapper mapper;
+
+    @MockitoSpyBean
+    private RecipeRepositoryV3 repository;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestRecipe();
+        this.target = getTestSearchRecipeResponseBody();
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(2L)
+                .name("Test category")
+                .version(2L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(2L)
+                .name("Test measure unit")
+                .version(2L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(2L)
+                .name("Test ingredient")
+                .amount(2.0)
+                .measureUnit(measureUnit)
+                .version(2L)
+                .build();
+        return Recipe.builder()
+                .id(2L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test instructions in Recipe")
+                .version(2L)
+                .build();
+    }
+
+    private static SearchRecipeResponseBody getTestSearchRecipeResponseBody() {
+        return SearchRecipeResponseBody.builder()
+                .owner("Test owner")
+                .id(1L)
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientResponseBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientResponseBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target and populates owner")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTargetAndPopulatesOwner() {
+        final Recipe source = repository.findAll().getFirst();
+        mapper.map(source, target);
+        assertEquals(source.getId(), target.getId());
+        assertEquals(source.getName(), target.getName());
+        assertEquals(source.getDescription(), target.getDescription());
+        assertEquals(source.getDifficulty(), target.getDifficulty());
+        equalCategories(source, target);
+        equalIngredients(source, target);
+        assertEquals(source.getServings(), target.getServings());
+        assertEquals(source.getCookingTime(), target.getCookingTime());
+        assertEquals(source.getInstructions(), target.getInstructions());
+        verify(repository, times(1))
+                .findOwner(source.getId());
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new SearchRecipeResponseBody and populate owner and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewSearchRecipeResponseBodyAndPopulatesOwnerAndReturnsIt() {
+        final Recipe source = repository.findAll().getFirst();
+        final SearchRecipeResponseBody searchRecipeResponseBody = mapper.mapToDTO(source);
+        assertEquals(source.getId(), searchRecipeResponseBody.getId());
+        assertEquals(source.getName(), searchRecipeResponseBody.getName());
+        assertEquals(source.getDescription(), searchRecipeResponseBody.getDescription());
+        assertEquals(source.getDifficulty(), searchRecipeResponseBody.getDifficulty());
+        equalCategories(source, searchRecipeResponseBody);
+        equalIngredients(source, searchRecipeResponseBody);
+        assertEquals(source.getServings(), searchRecipeResponseBody.getServings());
+        assertEquals(source.getCookingTime(), searchRecipeResponseBody.getCookingTime());
+        assertEquals(source.getInstructions(), searchRecipeResponseBody.getInstructions());
+        verify(repository, times(1))
+                .findOwner(source.getId());
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+
+    private static void equalCategories(Recipe source, SearchRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getCategories()
+                        .stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList(),
+                target.getCategories()
+                        .stream()
+                        .sorted()
+                        .toList()
+        );
+    }
+
+    private static void equalIngredients(Recipe source, SearchRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getUnit)
+                        .sorted()
+                        .toList()
+        );
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultRecipeToSearchRecipeResponseBodyMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultRecipeToSearchRecipeResponseBodyMapperUnitTest.java
@@ -1,0 +1,215 @@
+package com.askie01.recipeapplication.unit.mapper;
+
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.dto.SearchRecipeResponseBody;
+import com.askie01.recipeapplication.mapper.DefaultRecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DefaultRecipeToSearchRecipeResponseBodyMapper unit tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "unit")
+class DefaultRecipeToSearchRecipeResponseBodyMapperUnitTest {
+
+    private Recipe source;
+    private SearchRecipeResponseBody target;
+    private RecipeToSearchRecipeResponseBodyMapper mapper;
+
+    @Mock
+    private RecipeRepositoryV3 repository;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestRecipe();
+        this.target = getTestSearchRecipeResponseBody();
+        this.mapper = new DefaultRecipeToSearchRecipeResponseBodyMapper(repository);
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(2L)
+                .name("Test category")
+                .version(2L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(2L)
+                .name("Test measure unit")
+                .version(2L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(2L)
+                .name("Test ingredient")
+                .amount(2.0)
+                .measureUnit(measureUnit)
+                .version(2L)
+                .build();
+        return Recipe.builder()
+                .id(2L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test instructions in Recipe")
+                .version(2L)
+                .build();
+    }
+
+    private static SearchRecipeResponseBody getTestSearchRecipeResponseBody() {
+        return SearchRecipeResponseBody.builder()
+                .owner("Test owner")
+                .id(1L)
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientResponseBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientResponseBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target and populates owner")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTargetAndPopulatesOwner() {
+        when(repository.findOwner(any(Long.class)))
+                .thenReturn(Optional.of("Test owner"));
+
+        mapper.map(source, target);
+        assertEquals(source.getId(), target.getId());
+        assertEquals(source.getName(), target.getName());
+        assertEquals(source.getDescription(), target.getDescription());
+        assertEquals(source.getDifficulty(), target.getDifficulty());
+        equalCategories(source, target);
+        equalIngredients(source, target);
+        assertEquals(source.getServings(), target.getServings());
+        assertEquals(source.getCookingTime(), target.getCookingTime());
+        assertEquals(source.getInstructions(), target.getInstructions());
+        verify(repository, times(1))
+                .findOwner(source.getId());
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new SearchRecipeResponseBody and populate owner and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewSearchRecipeResponseBodyAndPopulatesOwnerAndReturnsIt() {
+        when(repository.findOwner(any(Long.class)))
+                .thenReturn(Optional.of("Test owner"));
+        final SearchRecipeResponseBody searchRecipeResponseBody = mapper.mapToDTO(source);
+        assertEquals(source.getId(), searchRecipeResponseBody.getId());
+        assertEquals(source.getName(), searchRecipeResponseBody.getName());
+        assertEquals(source.getDescription(), searchRecipeResponseBody.getDescription());
+        assertEquals(source.getDifficulty(), searchRecipeResponseBody.getDifficulty());
+        equalCategories(source, searchRecipeResponseBody);
+        equalIngredients(source, searchRecipeResponseBody);
+        assertEquals(source.getServings(), searchRecipeResponseBody.getServings());
+        assertEquals(source.getCookingTime(), searchRecipeResponseBody.getCookingTime());
+        assertEquals(source.getInstructions(), searchRecipeResponseBody.getInstructions());
+        verify(repository, times(1))
+                .findOwner(source.getId());
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+
+    private static void equalCategories(Recipe source, SearchRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getCategories()
+                        .stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList(),
+                target.getCategories()
+                        .stream()
+                        .sorted()
+                        .toList()
+        );
+    }
+
+    private static void equalIngredients(Recipe source, SearchRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getUnit)
+                        .sorted()
+                        .toList()
+        );
+    }
+}
+


### PR DESCRIPTION
* Created mapper interface & default implementation class to perform `Recipe` object data mapping to the corresponding `SearchRecipeResponseBody` object
* Created both unit & integration tests to make sure this component works as expected in both isolated & spring environments.
* Created configuration class & new property in `additional-spring-configuration-metadata.json` as a configuration key for easier bean management.
* This pull request closes #541 