### PR TITLE
535 create reciperestcontrollerv3

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/api/v3/RecipeRestControllerV3.java
+++ b/src/main/java/com/askie01/recipeapplication/api/v3/RecipeRestControllerV3.java
@@ -1,0 +1,120 @@
+package com.askie01.recipeapplication.api.v3;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.dto.CustomerRecipeResponseBody;
+import com.askie01.recipeapplication.dto.PageResponse;
+import com.askie01.recipeapplication.dto.SearchRecipeResponseBody;
+import com.askie01.recipeapplication.mapper.RecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.service.RecipeServiceV3;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Validated
+@RestController
+@RequestMapping("/api/v3/recipes")
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "api.recipe.v3.enabled", havingValue = "true", matchIfMissing = true)
+public class RecipeRestControllerV3 {
+
+    private final RecipeServiceV3 service;
+    private final RecipeToSearchRecipeResponseBodyMapper recipeToSearchRecipeMapper;
+    private final RecipeToCustomerRecipeResponseBodyMapper recipeToCustomerRecipeMapper;
+
+    @PostMapping
+    public ResponseEntity<Void> createRecipe(Authentication authentication,
+                                             @Valid @RequestBody CustomerRecipeRequestBody requestBody) {
+        final String username = authentication.getName();
+        service.createRecipe(username, requestBody);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SearchRecipeResponseBody> getRecipe(@PathVariable Long id) {
+        final Recipe recipe = service.getRecipe(id);
+        final SearchRecipeResponseBody responseBody = recipeToSearchRecipeMapper.mapToDTO(recipe);
+        return new ResponseEntity<>(responseBody, HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/{id}/image", produces = MediaType.IMAGE_JPEG_VALUE)
+    public ResponseEntity<byte[]> getRecipeImage(@PathVariable Long id) {
+        final byte[] recipeImage = service.getRecipeImage(id);
+        return new ResponseEntity<>(recipeImage, HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<CustomerRecipeResponseBody>> getUserRecipes(@RequestParam(
+                                                                                           required = false,
+                                                                                           defaultValue = ""
+                                                                                   ) String username,
+                                                                                   Pageable pageable) {
+        final Page<CustomerRecipeResponseBody> recipes = service
+                .getCustomerRecipes(username, pageable)
+                .map(recipeToCustomerRecipeMapper::mapToDTO);
+        final PageResponse<CustomerRecipeResponseBody> responseBody = PageResponse.from(recipes);
+        return new ResponseEntity<>(responseBody, HttpStatus.OK);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<PageResponse<SearchRecipeResponseBody>> searchRecipes(@RequestParam(
+                                                                                        required = false,
+                                                                                        defaultValue = ""
+                                                                                ) String query,
+                                                                                @PageableDefault(
+                                                                                        sort = "name",
+                                                                                        direction = Sort.Direction.ASC
+                                                                                ) Pageable pageable) {
+        final Page<SearchRecipeResponseBody> recipes = service
+                .searchRecipes(query, pageable)
+                .map(recipeToSearchRecipeMapper::mapToDTO);
+        final PageResponse<SearchRecipeResponseBody> responseBody = PageResponse.from(recipes);
+        return new ResponseEntity<>(responseBody, HttpStatus.OK);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateRecipeDetails(Authentication authentication,
+                                                    @PathVariable Long id,
+                                                    @Valid @RequestBody CustomerRecipeRequestBody requestBody) {
+        final String username = authentication.getName();
+        service.updateRecipe(username, id, requestBody);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PutMapping(value = "/{id}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> updateRecipeImage(Authentication authentication,
+                                                  @PathVariable Long id,
+                                                  @RequestPart MultipartFile image) {
+        final String username = authentication.getName();
+        service.updateImage(username, id, image);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PutMapping("/{id}/image/restore")
+    public ResponseEntity<Void> restoreDefaultRecipeImage(Authentication authentication,
+                                                          @PathVariable Long id) {
+        final String username = authentication.getName();
+        service.restoreDefaultImage(username, id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteRecipe(Authentication authentication,
+                                             @PathVariable Long id) {
+        final String username = authentication.getName();
+        service.deleteRecipe(username, id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/configuration/CustomerRecipeRequestBodyToRecipeMapperConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/CustomerRecipeRequestBodyToRecipeMapperConfiguration.java
@@ -1,0 +1,23 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.CustomerRecipeRequestBodyToRecipeMapper;
+import com.askie01.recipeapplication.mapper.DefaultCustomerRecipeRequestBodyToRecipeMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class CustomerRecipeRequestBodyToRecipeMapperConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            name = "component.mapper.customer-recipe-request-body-to-recipe",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public CustomerRecipeRequestBodyToRecipeMapper defaultCustomerRecipeRequestBodyToRecipeMapper() {
+        return new DefaultCustomerRecipeRequestBodyToRecipeMapper();
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/configuration/RecipeServiceV3Configuration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/RecipeServiceV3Configuration.java
@@ -1,0 +1,28 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.CustomerRecipeRequestBodyToRecipeMapper;
+import com.askie01.recipeapplication.repository.CustomerRepositoryV1;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import com.askie01.recipeapplication.service.DefaultRecipeServiceV3;
+import com.askie01.recipeapplication.service.RecipeServiceV3;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class RecipeServiceV3Configuration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            name = "component.service.recipe-v3",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public RecipeServiceV3 defaultRecipeServiceV3(RecipeRepositoryV3 recipeRepository,
+                                                  CustomerRepositoryV1 customerRepository,
+                                                  CustomerRecipeRequestBodyToRecipeMapper customerRecipeRequestBodyMapper) {
+        return new DefaultRecipeServiceV3(recipeRepository, customerRepository, customerRecipeRequestBodyMapper);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/configuration/RecipeToCustomerRecipeResponseBodyMapperConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/RecipeToCustomerRecipeResponseBodyMapperConfiguration.java
@@ -1,0 +1,23 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.DefaultRecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToCustomerRecipeResponseBodyMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class RecipeToCustomerRecipeResponseBodyMapperConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            name = "component.mapper.recipe-to-customer-recipe-response-body",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public RecipeToCustomerRecipeResponseBodyMapper defaultRecipeToCustomerRecipeResponseBodyMapper() {
+        return new DefaultRecipeToCustomerRecipeResponseBodyMapper();
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/configuration/RecipeToSearchRecipeResponseBodyMapperConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/RecipeToSearchRecipeResponseBodyMapperConfiguration.java
@@ -1,0 +1,24 @@
+package com.askie01.recipeapplication.configuration;
+
+import com.askie01.recipeapplication.mapper.DefaultRecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class RecipeToSearchRecipeResponseBodyMapperConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            value = "component.mapper.recipe-to-search-recipe-response-body",
+            havingValue = "default",
+            matchIfMissing = true
+    )
+    public RecipeToSearchRecipeResponseBodyMapper defaultRecipeToSearchRecipeResponseBodyMapper(RecipeRepositoryV3 recipeRepositoryV3) {
+        return new DefaultRecipeToSearchRecipeResponseBodyMapper(recipeRepositoryV3);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/configuration/SecurityFilterChainConfiguration.java
+++ b/src/main/java/com/askie01/recipeapplication/configuration/SecurityFilterChainConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityFilterChainConfiguration {
 
     private static final String RECIPE_API_V2 = "/api/v2/recipes/**";
+    private static final String RECIPE_API_V3 = "/api/v3/recipes/**";
     private static final String CUSTOMERS_API_V1 = "/api/v1/customers/**";
 
     @Bean
@@ -20,6 +21,9 @@ public class SecurityFilterChainConfiguration {
                         .requestMatchers(HttpMethod.POST, RECIPE_API_V2).authenticated()
                         .requestMatchers(HttpMethod.PUT, RECIPE_API_V2).authenticated()
                         .requestMatchers(HttpMethod.DELETE, RECIPE_API_V2).authenticated()
+                        .requestMatchers(HttpMethod.POST, RECIPE_API_V3).authenticated()
+                        .requestMatchers(HttpMethod.PUT, RECIPE_API_V3).authenticated()
+                        .requestMatchers(HttpMethod.DELETE, RECIPE_API_V3).authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/customers/details").authenticated()
                         .requestMatchers(HttpMethod.PUT, CUSTOMERS_API_V1).authenticated()
                         .requestMatchers(HttpMethod.DELETE, CUSTOMERS_API_V1).authenticated()

--- a/src/main/java/com/askie01/recipeapplication/dto/CustomerRecipeRequestBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/CustomerRecipeRequestBody.java
@@ -1,0 +1,24 @@
+package com.askie01.recipeapplication.dto;
+
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import lombok.*;
+
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@EqualsAndHashCode
+public class CustomerRecipeRequestBody {
+    private String name;
+    private String description;
+    private Difficulty difficulty;
+    private Set<String> categories;
+    private Set<IngredientRequestBody> ingredients;
+    private Double servings;
+    private Integer cookingTime;
+    private String instructions;
+}

--- a/src/main/java/com/askie01/recipeapplication/dto/CustomerRecipeResponseBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/CustomerRecipeResponseBody.java
@@ -1,0 +1,25 @@
+package com.askie01.recipeapplication.dto;
+
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import lombok.*;
+
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@EqualsAndHashCode
+public class CustomerRecipeResponseBody {
+    private Long id;
+    private String name;
+    private String description;
+    private Difficulty difficulty;
+    private Set<String> categories;
+    private Set<IngredientResponseBody> ingredients;
+    private Double servings;
+    private Integer cookingTime;
+    private String instructions;
+}

--- a/src/main/java/com/askie01/recipeapplication/dto/SearchRecipeResponseBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/SearchRecipeResponseBody.java
@@ -1,0 +1,26 @@
+package com.askie01.recipeapplication.dto;
+
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import lombok.*;
+
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@EqualsAndHashCode
+public class SearchRecipeResponseBody {
+    private String owner;
+    private Long id;
+    private String name;
+    private String description;
+    private Difficulty difficulty;
+    private Set<String> categories;
+    private Set<IngredientResponseBody> ingredients;
+    private Double servings;
+    private Integer cookingTime;
+    private String instructions;
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/CustomerRecipeRequestBodyToRecipeMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/CustomerRecipeRequestBodyToRecipeMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.model.entity.Recipe;
+
+public interface CustomerRecipeRequestBodyToRecipeMapper
+        extends Mapper<CustomerRecipeRequestBody, Recipe>,
+        ToEntityMapper<CustomerRecipeRequestBody, Recipe> {
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/DefaultCustomerRecipeRequestBodyToRecipeMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DefaultCustomerRecipeRequestBodyToRecipeMapper.java
@@ -1,0 +1,98 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DefaultCustomerRecipeRequestBodyToRecipeMapper implements CustomerRecipeRequestBodyToRecipeMapper {
+
+    @Override
+    public Recipe mapToEntity(CustomerRecipeRequestBody requestBody) {
+        final Recipe recipe = Recipe.builder()
+                .categories(new HashSet<>())
+                .ingredients(new HashSet<>())
+                .build();
+        map(requestBody, recipe);
+        return recipe;
+    }
+
+    @Override
+    public void map(CustomerRecipeRequestBody requestBody, Recipe recipe) {
+        mapName(requestBody, recipe);
+        mapDescription(requestBody, recipe);
+        mapDifficulty(requestBody, recipe);
+        mapCategories(requestBody, recipe);
+        mapIngredients(requestBody, recipe);
+        mapServings(requestBody, recipe);
+        mapCookingTime(requestBody, recipe);
+        mapInstructions(requestBody, recipe);
+    }
+
+    private void mapName(CustomerRecipeRequestBody requestBody, Recipe recipe) {
+        final String name = requestBody.getName();
+        recipe.setName(name);
+    }
+
+    private void mapDescription(CustomerRecipeRequestBody requestBody, Recipe recipe) {
+        final String description = requestBody.getDescription();
+        recipe.setDescription(description);
+    }
+
+    private void mapDifficulty(CustomerRecipeRequestBody requestBody, Recipe recipe) {
+        final Difficulty difficulty = requestBody.getDifficulty();
+        recipe.setDifficulty(difficulty);
+    }
+
+    private void mapCategories(CustomerRecipeRequestBody requestBody, Recipe recipe) {
+        final Set<Category> categories = requestBody.getCategories()
+                .stream()
+                .map(categoryName -> Category.builder().name(categoryName).build())
+                .collect(Collectors.toCollection(HashSet::new));
+        recipe.getCategories().clear();
+        recipe.getCategories().addAll(categories);
+    }
+
+    private void mapIngredients(CustomerRecipeRequestBody requestBody, Recipe recipe) {
+        final Set<Ingredient> ingredients = requestBody.getIngredients()
+                .stream()
+                .map(ingredientRequestBody -> {
+                    final String ingredientName = ingredientRequestBody.getName();
+                    final Double amount = ingredientRequestBody.getAmount();
+                    final String unit = ingredientRequestBody.getUnit();
+
+                    final MeasureUnit measureUnit = MeasureUnit.builder()
+                            .name(unit)
+                            .build();
+                    return Ingredient.builder()
+                            .name(ingredientName)
+                            .amount(amount)
+                            .measureUnit(measureUnit)
+                            .build();
+                })
+                .collect(Collectors.toCollection(HashSet::new));
+        recipe.getIngredients().clear();
+        recipe.getIngredients().addAll(ingredients);
+    }
+
+    private void mapServings(CustomerRecipeRequestBody requestBody, Recipe recipe) {
+        final Double servings = requestBody.getServings();
+        recipe.setServings(servings);
+    }
+
+    private void mapCookingTime(CustomerRecipeRequestBody requestBody, Recipe recipe) {
+        final Integer cookingTime = requestBody.getCookingTime();
+        recipe.setCookingTime(cookingTime);
+    }
+
+    private void mapInstructions(CustomerRecipeRequestBody requestBody, Recipe recipe) {
+        final String instructions = requestBody.getInstructions();
+        recipe.setInstructions(instructions);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapper.java
@@ -1,0 +1,90 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeResponseBody;
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DefaultRecipeToCustomerRecipeResponseBodyMapper implements RecipeToCustomerRecipeResponseBodyMapper {
+
+    @Override
+    public CustomerRecipeResponseBody mapToDTO(Recipe recipe) {
+        final CustomerRecipeResponseBody customerRecipeResponseBody = new CustomerRecipeResponseBody();
+        map(recipe, customerRecipeResponseBody);
+        return customerRecipeResponseBody;
+    }
+
+    @Override
+    public void map(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        mapId(recipe, responseBody);
+        mapName(recipe, responseBody);
+        mapDescription(recipe, responseBody);
+        mapDifficulty(recipe, responseBody);
+        mapCategories(recipe, responseBody);
+        mapIngredients(recipe, responseBody);
+        mapServings(recipe, responseBody);
+        mapCookingTime(recipe, responseBody);
+        mapInstructions(recipe, responseBody);
+    }
+
+    private void mapId(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Long id = recipe.getId();
+        responseBody.setId(id);
+    }
+
+    private void mapName(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final String name = recipe.getName();
+        responseBody.setName(name);
+    }
+
+    private void mapDifficulty(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Difficulty difficulty = recipe.getDifficulty();
+        responseBody.setDifficulty(difficulty);
+    }
+
+    private void mapCategories(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Set<String> categories = recipe.getCategories()
+                .stream()
+                .map(Category::getName)
+                .collect(Collectors.toCollection(HashSet::new));
+        responseBody.setCategories(categories);
+    }
+
+    private void mapIngredients(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Set<IngredientResponseBody> ingredients = recipe.getIngredients()
+                .stream()
+                .map(ingredient -> {
+                    final String name = ingredient.getName();
+                    final Double amount = ingredient.getAmount();
+                    final String unit = ingredient.getMeasureUnit().getName();
+                    return new IngredientResponseBody(name, amount, unit);
+                })
+                .collect(Collectors.toCollection(HashSet::new));
+        responseBody.setIngredients(ingredients);
+    }
+
+    private void mapServings(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Double servings = recipe.getServings();
+        responseBody.setServings(servings);
+    }
+
+    private void mapCookingTime(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final Integer cookingTime = recipe.getCookingTime();
+        responseBody.setCookingTime(cookingTime);
+    }
+
+    private void mapDescription(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final String description = recipe.getDescription();
+        responseBody.setDescription(description);
+    }
+
+    private void mapInstructions(Recipe recipe, CustomerRecipeResponseBody responseBody) {
+        final String instructions = recipe.getInstructions();
+        responseBody.setInstructions(instructions);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/DefaultRecipeToSearchRecipeResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/DefaultRecipeToSearchRecipeResponseBodyMapper.java
@@ -1,0 +1,112 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.dto.SearchRecipeResponseBody;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class DefaultRecipeToSearchRecipeResponseBodyMapper implements RecipeToSearchRecipeResponseBodyMapper {
+
+    private final RecipeRepositoryV3 repository;
+
+    @Override
+    public SearchRecipeResponseBody mapToDTO(Recipe recipe) {
+        final SearchRecipeResponseBody searchRecipeResponseBody = new SearchRecipeResponseBody();
+        map(recipe, searchRecipeResponseBody);
+        return searchRecipeResponseBody;
+    }
+
+    @Override
+    public void map(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        mapId(recipe, searchRecipeResponseBody);
+        mapName(recipe, searchRecipeResponseBody);
+        mapDescription(recipe, searchRecipeResponseBody);
+        mapDifficulty(recipe, searchRecipeResponseBody);
+        mapCategories(recipe, searchRecipeResponseBody);
+        mapIngredients(recipe, searchRecipeResponseBody);
+        mapServings(recipe, searchRecipeResponseBody);
+        mapCookingTime(recipe, searchRecipeResponseBody);
+        mapInstructions(recipe, searchRecipeResponseBody);
+        mapOwner(recipe, searchRecipeResponseBody);
+    }
+
+    private void mapOwner(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Long recipeId = recipe.getId();
+        final String owner = repository
+                .findOwner(recipeId)
+                .orElseThrow(() -> new UsernameNotFoundException("Recipe with id: " + recipeId + " does not have owner"));
+        searchRecipeResponseBody.setOwner(owner);
+    }
+
+    private void mapId(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Long id = recipe.getId();
+        searchRecipeResponseBody.setId(id);
+    }
+
+    private void mapName(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final String name = recipe.getName();
+        searchRecipeResponseBody.setName(name);
+    }
+
+    private void mapDescription(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final String description = recipe.getDescription();
+        searchRecipeResponseBody.setDescription(description);
+    }
+
+    private void mapDifficulty(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Difficulty difficulty = recipe.getDifficulty();
+        searchRecipeResponseBody.setDifficulty(difficulty);
+    }
+
+    private void mapCategories(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Set<String> categories = recipe.getCategories()
+                .stream()
+                .map(Category::getName)
+                .collect(Collectors.toCollection(HashSet::new));
+        searchRecipeResponseBody.setCategories(categories);
+    }
+
+    private void mapIngredients(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Set<IngredientResponseBody> ingredients = recipe.getIngredients()
+                .stream()
+                .map(this::mapToIngredientResponseBody)
+                .collect(Collectors.toCollection(HashSet::new));
+        searchRecipeResponseBody.setIngredients(ingredients);
+    }
+
+    private IngredientResponseBody mapToIngredientResponseBody(Ingredient ingredient) {
+        final String name = ingredient.getName();
+        final Double amount = ingredient.getAmount();
+        final String unit = ingredient.getMeasureUnit().getName();
+        return IngredientResponseBody.builder()
+                .name(name)
+                .amount(amount)
+                .unit(unit)
+                .build();
+    }
+
+    private void mapServings(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Double servings = recipe.getServings();
+        searchRecipeResponseBody.setServings(servings);
+    }
+
+    private void mapCookingTime(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final Integer cookingTime = recipe.getCookingTime();
+        searchRecipeResponseBody.setCookingTime(cookingTime);
+    }
+
+    private void mapInstructions(Recipe recipe, SearchRecipeResponseBody searchRecipeResponseBody) {
+        final String instructions = recipe.getInstructions();
+        searchRecipeResponseBody.setInstructions(instructions);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/RecipeToCustomerRecipeResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/RecipeToCustomerRecipeResponseBodyMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeResponseBody;
+import com.askie01.recipeapplication.model.entity.Recipe;
+
+public interface RecipeToCustomerRecipeResponseBodyMapper
+        extends Mapper<Recipe, CustomerRecipeResponseBody>,
+        ToDTOMapper<Recipe, CustomerRecipeResponseBody> {
+}

--- a/src/main/java/com/askie01/recipeapplication/mapper/RecipeToSearchRecipeResponseBodyMapper.java
+++ b/src/main/java/com/askie01/recipeapplication/mapper/RecipeToSearchRecipeResponseBodyMapper.java
@@ -1,0 +1,9 @@
+package com.askie01.recipeapplication.mapper;
+
+import com.askie01.recipeapplication.dto.SearchRecipeResponseBody;
+import com.askie01.recipeapplication.model.entity.Recipe;
+
+public interface RecipeToSearchRecipeResponseBodyMapper
+        extends Mapper<Recipe, SearchRecipeResponseBody>,
+        ToDTOMapper<Recipe, SearchRecipeResponseBody> {
+}

--- a/src/main/java/com/askie01/recipeapplication/model/entity/Recipe.java
+++ b/src/main/java/com/askie01/recipeapplication/model/entity/Recipe.java
@@ -20,7 +20,6 @@ import java.util.Set;
 @AllArgsConstructor
 @SuperBuilder
 @ToString
-@EqualsAndHashCode
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "recipe")

--- a/src/main/java/com/askie01/recipeapplication/repository/RecipeRepositoryV3.java
+++ b/src/main/java/com/askie01/recipeapplication/repository/RecipeRepositoryV3.java
@@ -1,0 +1,54 @@
+package com.askie01.recipeapplication.repository;
+
+import com.askie01.recipeapplication.model.entity.Recipe;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RecipeRepositoryV3 extends JpaRepository<Recipe, Long> {
+
+    @Query("""
+            SELECT r
+            FROM Customer c
+            JOIN c.recipes r
+            WHERE c.username = :username
+            """)
+    Page<Recipe> findByUsername(@Param("username") String username, Pageable pageable);
+
+    @Query("""
+            SELECT DISTINCT r
+            FROM Recipe r
+            JOIN r.categories c
+            JOIN r.ingredients i
+            JOIN i.measureUnit m
+            WHERE LOWER(r.name) LIKE LOWER(CONCAT('%', :query, '%'))
+            OR LOWER(r.description) LIKE LOWER(CONCAT('%', :query, '%'))
+            OR LOWER(r.difficulty) LIKE LOWER(CONCAT('%', :query, '%'))
+            OR LOWER(c.name) LIKE LOWER(CONCAT('%', :query, '%'))
+            OR LOWER(i.name) LIKE LOWER(CONCAT('%', :query, '%'))
+            OR LOWER(m.name) LIKE LOWER(CONCAT('%', :query, '%'))
+            OR LOWER(r.instructions) LIKE LOWER(CONCAT('%', :query, '%'))
+            """)
+    Page<Recipe> searchRecipes(@Param("query") String query, Pageable pageable);
+
+    @Query("""
+            SELECT c.username
+            FROM Customer c
+            JOIN c.recipes r
+            WHERE r.id = :id
+            """)
+    Optional<String> findOwner(@Param("id") Long id);
+
+    @Query("""
+            SELECT r.image
+            FROM Recipe r
+            WHERE r.id = :id
+            """)
+    Optional<byte[]> findRecipeImage(@Param("id") Long id);
+}

--- a/src/main/java/com/askie01/recipeapplication/service/DefaultRecipeServiceV3.java
+++ b/src/main/java/com/askie01/recipeapplication/service/DefaultRecipeServiceV3.java
@@ -1,0 +1,127 @@
+package com.askie01.recipeapplication.service;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.exception.RecipeNotFoundException;
+import com.askie01.recipeapplication.mapper.CustomerRecipeRequestBodyToRecipeMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.repository.CustomerRepositoryV1;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Objects;
+
+@RequiredArgsConstructor
+public class DefaultRecipeServiceV3 implements RecipeServiceV3 {
+
+    private final RecipeRepositoryV3 recipeRepository;
+    private final CustomerRepositoryV1 customerRepository;
+    private final CustomerRecipeRequestBodyToRecipeMapper customerRecipeRequestBodyMapper;
+    private final ClassPathResource classPathResource = new ClassPathResource("static/default-recipe.png");
+
+    @Override
+    @SneakyThrows
+    public void createRecipe(String username, CustomerRecipeRequestBody requestBody) {
+        final Customer customer = customerRepository
+                .findByUsernameIgnoreCase(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Username: '" + username + "' does not exist"));
+        final Recipe recipe = customerRecipeRequestBodyMapper.mapToEntity(requestBody);
+        final byte[] defaultImage = classPathResource.getContentAsByteArray();
+        recipe.setImage(defaultImage);
+        customer.getRecipes().add(recipe);
+        customerRepository.save(customer);
+    }
+
+    @Override
+    public Recipe getRecipe(Long id) {
+        return recipeRepository
+                .findById(id)
+                .orElseThrow(() -> new RecipeNotFoundException(id));
+    }
+
+    @Override
+    public byte[] getRecipeImage(Long id) {
+        return recipeRepository
+                .findRecipeImage(id)
+                .orElseThrow(() -> new RecipeNotFoundException(id));
+    }
+
+    @Override
+    public Page<Recipe> getCustomerRecipes(String username, Pageable pageable) {
+        return recipeRepository.findByUsername(username, pageable);
+    }
+
+    @Override
+    public Page<Recipe> searchRecipes(String query, Pageable pageable) {
+        return recipeRepository.searchRecipes(query, pageable);
+    }
+
+    @Override
+    public void updateRecipe(String username, Long id, CustomerRecipeRequestBody requestBody) {
+        final Customer customer = customerRepository
+                .findByUsernameIgnoreCase(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Username: '" + username + "' does not exist"));
+        final Recipe recipeToUpdate = customer.getRecipes()
+                .stream()
+                .filter(recipe -> recipe.getId().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new RecipeNotFoundException(id));
+        customerRecipeRequestBodyMapper.map(requestBody, recipeToUpdate);
+        recipeRepository.save(recipeToUpdate);
+    }
+
+    @Override
+    @SneakyThrows
+    public void updateImage(String username, Long id, MultipartFile image) {
+        final Recipe recipe = findCustomerRecipe(username, id);
+        final boolean isCorrectFormat = Objects
+                .requireNonNull(image.getContentType())
+                .startsWith("image/");
+        if (isCorrectFormat) {
+            final byte[] newImage = image.getBytes();
+            recipe.setImage(newImage);
+            recipeRepository.save(recipe);
+        } else {
+            throw new IllegalArgumentException("File: '" + image.getOriginalFilename() + "' is not jpeg");
+        }
+    }
+
+    @Override
+    @SneakyThrows
+    public void restoreDefaultImage(String username, Long id) {
+        final Recipe recipe = findCustomerRecipe(username, id);
+        final byte[] defaultImage = classPathResource.getContentAsByteArray();
+        recipe.setImage(defaultImage);
+        recipeRepository.save(recipe);
+    }
+
+    @Override
+    public void deleteRecipe(String username, Long id) {
+        final Customer customer = customerRepository
+                .findByUsernameIgnoreCase(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Username: '" + username + "' does not exist"));
+        final Recipe recipeToRemove = customer.getRecipes()
+                .stream()
+                .filter(recipe -> recipe.getId().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new RecipeNotFoundException(id));
+        customer.getRecipes().remove(recipeToRemove);
+        customerRepository.save(customer);
+    }
+
+    private Recipe findCustomerRecipe(String username, Long id) {
+        return customerRepository
+                .findByUsernameIgnoreCase(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Username: '" + username + "' does not exist")).getRecipes()
+                .stream()
+                .filter(recipe -> recipe.getId().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new RecipeNotFoundException(id));
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/service/RecipeServiceV3.java
+++ b/src/main/java/com/askie01/recipeapplication/service/RecipeServiceV3.java
@@ -1,0 +1,28 @@
+package com.askie01.recipeapplication.service;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface RecipeServiceV3 {
+
+    void createRecipe(String username, CustomerRecipeRequestBody requestBody);
+
+    Recipe getRecipe(Long id);
+
+    byte[] getRecipeImage(Long id);
+
+    Page<Recipe> getCustomerRecipes(String username, Pageable pageable);
+
+    Page<Recipe> searchRecipes(String query, Pageable pageable);
+
+    void updateRecipe(String username, Long id, CustomerRecipeRequestBody requestBody);
+
+    void updateImage(String username, Long id, MultipartFile image);
+
+    void restoreDefaultImage(String username, Long id);
+
+    void deleteRecipe(String username, Long id);
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -243,6 +243,12 @@
       "defaultValue": "default"
     },
     {
+      "name": "component.mapper.recipe-to-search-recipe-response-body",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'RecipeToSearchRecipeResponseBody' mapper type.",
+      "defaultValue": "default"
+    },
+    {
       "name": "component.service.recipe",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'RecipeService' implementation.",

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -312,6 +312,12 @@
       "defaultValue": true
     },
     {
+      "name": "api.recipe.v3.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Property used to enable/disable 'RecipeRestControllerV3' API.",
+      "defaultValue": true
+    },
+    {
       "name": "api.customer.v1.enabled",
       "type": "java.lang.String",
       "description": "Property used to enable/disable 'CustomerRestControllerV1' API.",

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -237,6 +237,12 @@
       "defaultValue": "default"
     },
     {
+      "name": "component.mapper.recipe-to-customer-recipe-response-body",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'RecipeToCustomerRecipeResponseBody' mapper type.",
+      "defaultValue": "default"
+    },
+    {
       "name": "component.service.recipe",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'RecipeService' implementation.",

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -249,6 +249,12 @@
       "defaultValue": "default"
     },
     {
+      "name": "component.service.recipe-v3",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'RecipeServiceV3' implementation.",
+      "defaultValue": "default"
+    },
+    {
       "name": "component.service.customer-v1",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'CustomerServiceV1' implementation.",

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -231,6 +231,12 @@
       "defaultValue": "default"
     },
     {
+      "name": "component.mapper.customer-recipe-request-body-to-recipe-type",
+      "type": "java.lang.String",
+      "description": "Property used to wire a correct 'CustomerRecipeRequestBodyToRecipe' mapper type.",
+      "defaultValue": "default"
+    },
+    {
       "name": "component.service.recipe",
       "type": "java.lang.String",
       "description": "Property used to wire a correct 'RecipeService' implementation.",

--- a/src/test/java/com/askie01/recipeapplication/integration/api/v3/RecipeRestControllerV3IntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/api/v3/RecipeRestControllerV3IntegrationTest.java
@@ -1,0 +1,481 @@
+package com.askie01.recipeapplication.integration.api.v3;
+
+import com.askie01.recipeapplication.api.v3.RecipeRestControllerV3;
+import com.askie01.recipeapplication.configuration.*;
+import com.askie01.recipeapplication.dto.*;
+import com.askie01.recipeapplication.model.entity.Customer;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.CustomerRepositoryV1;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.AutoConfigureDataJpa;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
+import org.springframework.test.web.servlet.client.RestTestClient;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = RecipeRestControllerV3.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@AutoConfigureDataJpa
+@AutoConfigureRestTestClient
+@Import(value = {
+        RecipeServiceV3Configuration.class,
+        CustomerRecipeRequestBodyToRecipeMapperConfiguration.class,
+        RecipeToSearchRecipeResponseBodyMapperConfiguration.class,
+        RecipeToCustomerRecipeResponseBodyMapperConfiguration.class,
+        UserDetailsServiceConfiguration.class,
+        CustomerToUserDetailsMapperConfiguration.class,
+        SecurityFilterChainConfiguration.class,
+        PasswordEncoderConfiguration.class,
+        JpaAuditingConfiguration.class
+})
+@TestPropertySource(properties = {
+        "api.recipe.v3.enabled=true",
+        "component.service.recipe-v3=default",
+        "component.mapper.customer-recipe-request-body-to-recipe-type=default",
+        "component.mapper.recipe-to-search-recipe-response-body=default",
+        "component.mapper.recipe-to-customer-recipe-response-body=default",
+        "component.service.user-details=default",
+        "component.mapper.customer-to-user-details=default",
+        "component.auditor-type=recipe-service-auditor",
+})
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("RecipeRestControllerV3 integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class RecipeRestControllerV3IntegrationTest {
+
+    private CustomerRecipeRequestBody requestBody;
+    private final RecipeRepositoryV3 recipeRepository;
+    private final CustomerRepositoryV1 customerRepository;
+    private final MockMvc mockMvc;
+    private final RestTestClient restTestClient;
+
+    @BeforeEach
+    void setUp() {
+        this.requestBody = getTestCustomerRecipeRequestBody();
+    }
+
+    private static CustomerRecipeRequestBody getTestCustomerRecipeRequestBody() {
+        return CustomerRecipeRequestBody.builder()
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientRequestBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientRequestBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("createRecipe method should return HTTP created when user is authenticated and request body is valid")
+    void createRecipe_whenUserIsAuthenticated_andRequestBodyIsValid_returnsHttpCreated() {
+        restTestClient.post().uri("/api/v3/recipes")
+                .headers(header -> header.setBasicAuth("user", "user"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .exchange()
+                .expectStatus()
+                .isCreated();
+    }
+
+    @Test
+    @DisplayName("createRecipe method should return HTTP unauthorized when user is unauthenticated")
+    void createRecipe_whenUserIsUnauthenticated_returnsHttpUnauthorized() {
+        restTestClient.post().uri("/api/v3/recipes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .exchange()
+                .expectStatus()
+                .isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("createRecipe method should return HTTP internal server error when user is authenticated and request body is invalid")
+    void createRecipe_whenUserIsAuthenticated_andRequestBodyIsInvalid_returnsHttpInternalServerError() {
+        restTestClient.post().uri("/api/v3/recipes")
+                .headers(header -> header.setBasicAuth("user", "user"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new CustomerRecipeRequestBody())
+                .exchange()
+                .expectStatus()
+                .is5xxServerError();
+    }
+
+    @Test
+    @DisplayName("createRecipe method should return HTTP bad request when user is authenticated and request body is not provided")
+    void createRecipe_whenUserIsAuthenticated_andRequestBodyIsNotProvided_returnsHttpBadRequest() {
+        restTestClient.post().uri("/api/v3/recipes")
+                .headers(header -> header.setBasicAuth("user", "user"))
+                .exchange()
+                .expectStatus()
+                .isBadRequest();
+    }
+
+    @Test
+    @DisplayName("getRecipe method should return recipe when recipe with given id exists")
+    void getRecipe_whenRecipeIdExists_returnsRecipeWithThatId() {
+        final Long recipeId = recipeRepository.findAll().stream().findAny().orElseThrow().getId();
+        final EntityExchangeResult<CustomerRecipeResponseBody> response = restTestClient.get().uri("/api/v3/recipes/{id}", recipeId)
+                .exchange()
+                .returnResult(CustomerRecipeResponseBody.class);
+        assertNotNull(response.getResponseBody());
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("getRecipe method should return HTTP not found when recipe id does not exist")
+    void getRecipe_whenRecipeIdDoesNotExist_returnsHttpNotFound() {
+        final Long nonExistentRecipeId = Long.MAX_VALUE;
+        restTestClient.get().uri("/api/v3/recipes/{id}", nonExistentRecipeId)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+    }
+
+    @Test
+    @DisplayName("getRecipeImage method should return recipe image when recipe with given id exists")
+    void getRecipeImage_whenRecipeIdExists_returnsRecipeImageWithThatId() {
+        final Long recipeId = recipeRepository.findAll().stream().findAny().orElseThrow().getId();
+        final EntityExchangeResult<byte[]> response = restTestClient.get().uri("/api/v3/recipes/{id}/image", recipeId)
+                .exchange()
+                .returnResult(byte[].class);
+        assertNotNull(response.getResponseBody());
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("getRecipeImage method should return HTTP not found when recipe with given id does not exist")
+    void getRecipeImage_whenRecipeIdDoesNotExist_returnsHttpNotFound() {
+        final Long nonExistentRecipeId = Long.MAX_VALUE;
+        restTestClient.get().uri("/api/v3/recipes/{id}/image", nonExistentRecipeId)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+    }
+
+    @Test
+    @DisplayName("getRecipeImage method should return HTTP bad request when recipe id is not provided")
+    void getRecipeImage_whenRecipeIdIsNotProvided_returnsHttpBadRequest() {
+        restTestClient.get().uri("/api/v3/recipes/image")
+                .exchange()
+                .expectStatus()
+                .isBadRequest();
+    }
+
+    @Test
+    @DisplayName("getUserRecipes method should return customer recipes page when customer with given username exists")
+    void getUserRecipes_whenUsernameExists_returnsCustomerRecipesPage() {
+        final String username = customerRepository.findAll().stream().findAny().orElseThrow().getUsername();
+        final EntityExchangeResult<PageResponse<CustomerRecipeResponseBody>> response = restTestClient
+                .get()
+                .uri("/api/v3/recipes?username={username}", username)
+                .exchange()
+                .returnResult(new ParameterizedTypeReference<>() {
+                });
+        assertNotNull(response.getResponseBody());
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("getUserRecipes method should return empty page when customer with given username does not exist")
+    void getUserRecipes_whenUsernameDoesNotExist_returnsEmptyPage() {
+        final String nonExistentUsername = "nonExistentUsername";
+        final EntityExchangeResult<PageResponse<CustomerRecipeResponseBody>> response = restTestClient
+                .get()
+                .uri("/api/v3/recipes?username={username}", nonExistentUsername)
+                .exchange()
+                .returnResult(new ParameterizedTypeReference<>() {
+                });
+        assertNotNull(response.getResponseBody());
+        assertTrue(response.getResponseBody().getItems().isEmpty());
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("getUserRecipes method should return empty page when username is not provided")
+    void getUserRecipes_whenUsernameIsNotProvided_returnsEmptyPage() {
+        final EntityExchangeResult<PageResponse<CustomerRecipeResponseBody>> response = restTestClient
+                .get()
+                .uri("/api/v3/recipes")
+                .exchange()
+                .returnResult(new ParameterizedTypeReference<>() {
+                });
+        assertNotNull(response.getResponseBody());
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("searchRecipes method should return recipes page when query matches recipes")
+    void searchRecipes_whenQueryMatchesRecipes_returnsRecipesPage() {
+        final String query = recipeRepository.findAll().stream().findAny().orElseThrow().getName();
+        final EntityExchangeResult<PageResponse<SearchRecipeResponseBody>> response = restTestClient
+                .get()
+                .uri("/api/v3/recipes/search?query={query}", query)
+                .exchange()
+                .returnResult(new ParameterizedTypeReference<>() {
+                });
+        assertNotNull(response.getResponseBody());
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("searchRecipes method should return empty page when query does not match recipes")
+    void searchRecipes_whenQueryDoesNotMatchRecipes_returnsEmptyPage() {
+        final String query = "nonExistentQuery";
+        final EntityExchangeResult<PageResponse<SearchRecipeResponseBody>> response = restTestClient
+                .get()
+                .uri("/api/v3/recipes/search?query={query}", query)
+                .exchange()
+                .returnResult(new ParameterizedTypeReference<>() {
+                });
+        assertNotNull(response.getResponseBody());
+        assertTrue(response.getResponseBody().getItems().isEmpty());
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("searchRecipes method should return random result page when query is not provided")
+    void searchRecipes_whenQueryIsNotProvided_returnsRandomResultPage() {
+        final EntityExchangeResult<PageResponse<SearchRecipeResponseBody>> response = restTestClient
+                .get()
+                .uri("/api/v3/recipes/search")
+                .exchange()
+                .returnResult(new ParameterizedTypeReference<>() {
+                });
+        assertNotNull(response.getResponseBody());
+        assertFalse(response.getResponseBody().getItems().isEmpty());
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("updateRecipeDetails method should return HTTP no content when user is authenticated, recipe id exists, and request body is valid")
+    void updateRecipeDetails_whenUserIsAuthenticated_recipeIdExists_andRequestBodyIsValid_returnsHttpNoContent() {
+        final Customer customer = customerRepository.findByUsernameIgnoreCase("user").orElseThrow();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = customer.getRecipes().stream().findAny().orElseThrow().getId();
+        restTestClient.put().uri("/api/v3/recipes/{id}", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+    }
+
+    @Test
+    @DisplayName("updateRecipeDetails method should return HTTP unauthorized when user is unauthenticated")
+    void updateRecipeDetails_whenUserIsUnauthenticated_returnsHttpUnauthorized() {
+        restTestClient.put().uri("/api/v3/recipes/{id}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .exchange()
+                .expectStatus()
+                .isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("updateRecipeDetails method should return HTTP not found when user is authenticated, but recipe id does not exist")
+    void updateRecipeDetails_whenUserIsAuthenticated_andRecipeIdDoesNotExist_returnsHttpNotFound() {
+        final Customer customer = customerRepository.findByUsernameIgnoreCase("user").orElseThrow();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long nonExistentRecipeId = Long.MAX_VALUE;
+        restTestClient.put().uri("/api/v3/recipes/{id}", nonExistentRecipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+    }
+
+    @Test
+    @DisplayName("updateRecipeDetails method should return HTTP internal server error when user is authenticated, recipe id exists, but request body is invalid")
+    void updateRecipeDetails_whenUserIsAuthenticated_andRecipeIdExists_andRequestBodyIsInvalid_returnsHttpInternalServerError() {
+        final Customer customer = customerRepository.findByUsernameIgnoreCase("user").orElseThrow();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = customer.getRecipes().stream().findAny().orElseThrow().getId();
+        restTestClient.put().uri("/api/v3/recipes/{id}", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new CustomerRecipeRequestBody())
+                .exchange()
+                .expectStatus()
+                .is5xxServerError();
+    }
+
+    @Test
+    @WithMockUser(username = "user", password = "user")
+    @DisplayName("updateRecipeImage method should return HTTP no content when user is authenticated, recipe id exists, and request body is valid")
+    void updateRecipeImage_whenUserIsAuthenticated_andRecipeIdExists_andImageIsValid_returnsHttpNoContent() throws Exception {
+        final Long recipeId = customerRepository
+                .findByUsernameIgnoreCase("user")
+                .orElseThrow()
+                .getRecipes()
+                .stream()
+                .findAny()
+                .orElseThrow()
+                .getId();
+        final MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "default-recipe.png",
+                MediaType.IMAGE_PNG_VALUE,
+                new ClassPathResource("static/default-recipe.png").getContentAsByteArray()
+        );
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/v3/recipes/{id}/image", recipeId)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .file(image))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("updateRecipeImage method should return HTTP unauthorized when user is unauthenticated")
+    void updateRecipeImage_whenUserIsUnauthenticated_returnsHttpUnauthorized() {
+        restTestClient.put().uri("/api/v3/recipes/{id}/image", 1L)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(new ClassPathResource("static/default-recipe.png"))
+                .exchange()
+                .expectStatus()
+                .isUnauthorized();
+    }
+
+    @Test
+    @WithMockUser(username = "user", password = "user")
+    @DisplayName("updateRecipeImage method should return HTTP not found when user is authenticated, but recipe id does not exist")
+    void updateRecipeImage_whenUserIsAuthenticated_andRecipeIdDoesNotExist_returnsHttpNotFound() throws Exception {
+        final Long recipeId = Long.MAX_VALUE;
+        final MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "default-recipe.png",
+                MediaType.IMAGE_PNG_VALUE,
+                new ClassPathResource("static/default-recipe.png").getContentAsByteArray()
+        );
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/v3/recipes/{id}/image", recipeId)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .file(image))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("updateRecipeImage method should return HTTP bad request when user is authenticated, recipe id exists, but request body is invalid")
+    void updateRecipeImage_whenUserIsAuthenticated_andRecipeIdExists_andImageIsInvalid_returnsHttpBadRequest() {
+        final Customer customer = customerRepository.findByUsernameIgnoreCase("user").orElseThrow();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = customer.getRecipes().stream().findAny().orElseThrow().getId();
+        restTestClient.put().uri("/api/v3/recipes/{id}/image", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body("Plain text")
+                .exchange()
+                .expectStatus()
+                .isBadRequest();
+    }
+
+    @Test
+    @DisplayName("restoreDefaultRecipeImage method should return HTTP no content when user is authenticated, and recipe id exists")
+    void restoreDefaultRecipeImage_whenUserIsAuthenticated_andRecipeIdExists_returnsHttpNoContent() {
+        final Customer customer = customerRepository.findByUsernameIgnoreCase("user").orElseThrow();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = customer.getRecipes().stream().findAny().orElseThrow().getId();
+        restTestClient.put().uri("/api/v3/recipes/{id}/image/restore", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+    }
+
+    @Test
+    @DisplayName("restoreDefaultRecipeImage method should return HTTP unauthorized when user is unauthenticated")
+    void restoreDefaultRecipeImage_whenUserIsUnauthenticated_returnsHttpUnauthorized() {
+        restTestClient.put().uri("/api/v3/recipes/{id}/image/restore", 1L)
+                .exchange()
+                .expectStatus()
+                .isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("restoreDefaultRecipeImage method should return HTTP not found when user is authenticated, but recipe id does not exist")
+    void restoreDefaultRecipeImage_whenUserIsAuthenticated_andRecipeIdDoesNotExist_returnsHttpNotFound() {
+        final Customer customer = customerRepository.findByUsernameIgnoreCase("user").orElseThrow();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = Long.MAX_VALUE;
+        restTestClient.put().uri("/api/v3/recipes/{id}/image/restore", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+    }
+
+    @Test
+    @DisplayName("deleteRecipe method should return HTTP no content when user is authenticated, and recipe id exists")
+    void deleteRecipe_whenUserIsAuthenticated_andRecipeIdExists_returnsHttpNoContent() {
+        final Customer customer = customerRepository.findByUsernameIgnoreCase("user").orElseThrow();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = customer.getRecipes().stream().findAny().orElseThrow().getId();
+        restTestClient.delete().uri("/api/v3/recipes/{id}", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+    }
+
+    @Test
+    @DisplayName("deleteRecipe method should return HTTP unauthorized when user is unauthenticated")
+    void deleteRecipe_whenUserIsUnauthenticated_returnsHttpUnauthorized() {
+        restTestClient.delete().uri("/api/v3/recipes/{id}", 1L)
+                .exchange()
+                .expectStatus()
+                .isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("deleteRecipe method should return HTTP not found when user is authenticated, but recipe id does not exist")
+    void deleteRecipe_whenUserIsAuthenticated_andRecipeIdDoesNotExist_returnsHttpNotFound() {
+        final Customer customer = customerRepository.findByUsernameIgnoreCase("user").orElseThrow();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long nonExistentRecipeId = Long.MAX_VALUE;
+        restTestClient.delete().uri("/api/v3/recipes/{id}", nonExistentRecipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultCustomerRecipeRequestBodyToRecipeMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultCustomerRecipeRequestBodyToRecipeMapperIntegrationTest.java
@@ -1,0 +1,224 @@
+package com.askie01.recipeapplication.integration.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.dto.IngredientRequestBody;
+import com.askie01.recipeapplication.mapper.CustomerRecipeRequestBodyToRecipeMapper;
+import com.askie01.recipeapplication.mapper.DefaultCustomerRecipeRequestBodyToRecipeMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringJUnitConfig(classes = DefaultCustomerRecipeRequestBodyToRecipeMapper.class)
+@TestPropertySource(properties = "component.mapper.customer-recipe-request-body-to-recipe-type=default")
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultCustomerRecipeRequestBodyToRecipeMapper integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultCustomerRecipeRequestBodyToRecipeMapperIntegrationTest {
+
+    private CustomerRecipeRequestBody source;
+    private Recipe target;
+    private final CustomerRecipeRequestBodyToRecipeMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestCustomerRecipeRequestBody();
+        this.target = getTestRecipe();
+    }
+
+    private static CustomerRecipeRequestBody getTestCustomerRecipeRequestBody() {
+        return CustomerRecipeRequestBody.builder()
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientRequestBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientRequestBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(2L)
+                .name("Test category")
+                .version(2L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(2L)
+                .name("Test measure unit")
+                .version(2L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(2L)
+                .name("Test ingredient")
+                .amount(2.0)
+                .measureUnit(measureUnit)
+                .version(2L)
+                .build();
+        return Recipe.builder()
+                .id(2L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test instructions in Recipe")
+                .version(2L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceName = source.getName();
+        final String targetName = target.getName();
+        assertEquals(sourceName, targetName);
+
+        final String sourceDescription = source.getDescription();
+        final String targetDescription = target.getDescription();
+        assertEquals(sourceDescription, targetDescription);
+
+        final Difficulty sourceDifficulty = source.getDifficulty();
+        final Difficulty targetDifficulty = target.getDifficulty();
+        assertEquals(sourceDifficulty, targetDifficulty);
+
+        equalCategories(source, target);
+        equalIngredients(source, target);
+
+        final Double sourceServings = source.getServings();
+        final Double targetServings = target.getServings();
+        assertEquals(sourceServings, targetServings);
+
+        final Integer sourceCookingTime = source.getCookingTime();
+        final Integer targetCookingTime = target.getCookingTime();
+        assertEquals(sourceCookingTime, targetCookingTime);
+
+        final String sourceInstructions = source.getInstructions();
+        final String targetInstructions = target.getInstructions();
+        assertEquals(sourceInstructions, targetInstructions);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should map all common fields from source to new Recipe and return it")
+    void mapToEntity_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewRecipeAndReturnIt() {
+        final Recipe recipe = mapper.mapToEntity(source);
+        final String sourceName = source.getName();
+        final String recipeName = recipe.getName();
+        assertEquals(sourceName, recipeName);
+
+        final String sourceDescription = source.getDescription();
+        final String recipeDescription = recipe.getDescription();
+        assertEquals(sourceDescription, recipeDescription);
+
+        final Difficulty sourceDifficulty = source.getDifficulty();
+        final Difficulty recipeDifficulty = recipe.getDifficulty();
+        assertEquals(sourceDifficulty, recipeDifficulty);
+
+        equalCategories(source, recipe);
+        equalIngredients(source, recipe);
+
+        final Double sourceServings = source.getServings();
+        final Double recipeServings = recipe.getServings();
+        assertEquals(sourceServings, recipeServings);
+
+        final Integer sourceCookingTime = source.getCookingTime();
+        final Integer recipeCookingTime = recipe.getCookingTime();
+        assertEquals(sourceCookingTime, recipeCookingTime);
+
+        final String sourceInstructions = source.getInstructions();
+        final String recipeInstructions = recipe.getInstructions();
+        assertEquals(sourceInstructions, recipeInstructions);
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should throw NullPointerException when source is null")
+    void mapToEntity_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToEntity(null));
+    }
+
+    private static void equalCategories(CustomerRecipeRequestBody source, Recipe target) {
+        assertIterableEquals(
+                source.getCategories().stream()
+                        .sorted()
+                        .toList(),
+                target.getCategories().stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList()
+        );
+    }
+
+    private static void equalIngredients(CustomerRecipeRequestBody source, Recipe target) {
+        assertIterableEquals(
+                source.getIngredients().stream()
+                        .map(IngredientRequestBody::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients().stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients().stream()
+                        .map(IngredientRequestBody::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients().stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients().stream()
+                        .map(IngredientRequestBody::getUnit)
+                        .sorted()
+                        .toList(),
+                target.getIngredients().stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList()
+        );
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapperIntegrationTest.java
@@ -1,0 +1,214 @@
+package com.askie01.recipeapplication.integration.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeResponseBody;
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.mapper.DefaultRecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringJUnitConfig(classes = DefaultRecipeToCustomerRecipeResponseBodyMapper.class)
+@TestPropertySource(properties = "component.mapper.recipe-to-customer-recipe-response-body=default")
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultRecipeToCustomerRecipeResponseBodyMapper integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultRecipeToCustomerRecipeResponseBodyMapperIntegrationTest {
+
+    private Recipe source;
+    private CustomerRecipeResponseBody target;
+    private final RecipeToCustomerRecipeResponseBodyMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestRecipe();
+        this.target = getTestCustomerRecipeResponseBody();
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(1L)
+                .name("Test category")
+                .version(1L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(1L)
+                .name("Test measure unit")
+                .version(1L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(1L)
+                .name("Test ingredient")
+                .amount(1.0)
+                .measureUnit(measureUnit)
+                .version(1L)
+                .build();
+        return Recipe.builder()
+                .id(1L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(1.0)
+                .cookingTime(10)
+                .instructions("Test instructions in Recipe")
+                .version(1L)
+                .build();
+    }
+
+    private static CustomerRecipeResponseBody getTestCustomerRecipeResponseBody() {
+        return CustomerRecipeResponseBody.builder()
+                .id(2L)
+                .name("Test customer recipe")
+                .description("Test customer description")
+                .difficulty(Difficulty.MEDIUM)
+                .categories(new HashSet<>(Set.of("Test customer category")))
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientResponseBody("Test customer ingredient", 1.0, "Test customer unit")
+                )))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test customer instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        assertEquals(source.getId(), target.getId());
+        assertEquals(source.getName(), target.getName());
+        assertEquals(source.getDescription(), target.getDescription());
+        equalCategories(source, target);
+        equalIngredients(source, target);
+        assertEquals(source.getServings(), target.getServings());
+        assertEquals(source.getCookingTime(), target.getCookingTime());
+        assertEquals(source.getInstructions(), target.getInstructions());
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new CustomerRecipeResponseBody and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerRecipeResponseBodyAndReturnIt() {
+        final CustomerRecipeResponseBody customerRecipeResponseBody = mapper.mapToDTO(source);
+        final Long sourceId = source.getId();
+        final Long customerRecipeResponseBodyId = customerRecipeResponseBody.getId();
+        assertEquals(sourceId, customerRecipeResponseBodyId);
+
+        final String sourceName = source.getName();
+        final String customerRecipeResponseBodyName = customerRecipeResponseBody.getName();
+        assertEquals(sourceName, customerRecipeResponseBodyName);
+
+        final String sourceDescription = source.getDescription();
+        final String customerRecipeResponseBodyDescription = customerRecipeResponseBody.getDescription();
+        assertEquals(sourceDescription, customerRecipeResponseBodyDescription);
+
+        final Difficulty sourceDifficulty = source.getDifficulty();
+        final Difficulty customerRecipeResponseBodyDifficulty = customerRecipeResponseBody.getDifficulty();
+        assertEquals(sourceDifficulty, customerRecipeResponseBodyDifficulty);
+
+        equalCategories(source, customerRecipeResponseBody);
+        equalIngredients(source, customerRecipeResponseBody);
+
+        final Double sourceServings = source.getServings();
+        final Double customerRecipeResponseBodyServings = customerRecipeResponseBody.getServings();
+        assertEquals(sourceServings, customerRecipeResponseBodyServings);
+
+        final Integer sourceCookingTime = source.getCookingTime();
+        final Integer customerRecipeResponseBodyCookingTime = customerRecipeResponseBody.getCookingTime();
+        assertEquals(sourceCookingTime, customerRecipeResponseBodyCookingTime);
+
+        final String sourceInstructions = source.getInstructions();
+        final String customerRecipeResponseBodyInstructions = customerRecipeResponseBody.getInstructions();
+        assertEquals(sourceInstructions, customerRecipeResponseBodyInstructions);
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+
+    private static void equalCategories(Recipe source, CustomerRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getCategories()
+                        .stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList(),
+                target.getCategories()
+                        .stream()
+                        .sorted()
+                        .toList());
+    }
+
+    private static void equalIngredients(Recipe source, CustomerRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getUnit)
+                        .sorted()
+                        .toList()
+        );
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultRecipeToSearchRecipeResponseBodyMapperIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/mapper/DefaultRecipeToSearchRecipeResponseBodyMapperIntegrationTest.java
@@ -1,0 +1,224 @@
+package com.askie01.recipeapplication.integration.mapper;
+
+import com.askie01.recipeapplication.configuration.JpaAuditingConfiguration;
+import com.askie01.recipeapplication.configuration.RecipeToSearchRecipeResponseBodyMapperConfiguration;
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.dto.SearchRecipeResponseBody;
+import com.askie01.recipeapplication.mapper.RecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Import(value = {
+        RecipeToSearchRecipeResponseBodyMapperConfiguration.class,
+        JpaAuditingConfiguration.class
+})
+@TestPropertySource(properties = {
+        "component.mapper.recipe-to-search-recipe-response-body=default",
+        "component.auditor-type=recipe-service-auditor"
+})
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultRecipeToSearchRecipeResponseBodyMapper integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultRecipeToSearchRecipeResponseBodyMapperIntegrationTest {
+
+    private Recipe source;
+    private SearchRecipeResponseBody target;
+    private final RecipeToSearchRecipeResponseBodyMapper mapper;
+
+    @MockitoSpyBean
+    private RecipeRepositoryV3 repository;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestRecipe();
+        this.target = getTestSearchRecipeResponseBody();
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(2L)
+                .name("Test category")
+                .version(2L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(2L)
+                .name("Test measure unit")
+                .version(2L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(2L)
+                .name("Test ingredient")
+                .amount(2.0)
+                .measureUnit(measureUnit)
+                .version(2L)
+                .build();
+        return Recipe.builder()
+                .id(2L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test instructions in Recipe")
+                .version(2L)
+                .build();
+    }
+
+    private static SearchRecipeResponseBody getTestSearchRecipeResponseBody() {
+        return SearchRecipeResponseBody.builder()
+                .owner("Test owner")
+                .id(1L)
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientResponseBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientResponseBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target and populates owner")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTargetAndPopulatesOwner() {
+        final Recipe source = repository.findAll().getFirst();
+        mapper.map(source, target);
+        assertEquals(source.getId(), target.getId());
+        assertEquals(source.getName(), target.getName());
+        assertEquals(source.getDescription(), target.getDescription());
+        assertEquals(source.getDifficulty(), target.getDifficulty());
+        equalCategories(source, target);
+        equalIngredients(source, target);
+        assertEquals(source.getServings(), target.getServings());
+        assertEquals(source.getCookingTime(), target.getCookingTime());
+        assertEquals(source.getInstructions(), target.getInstructions());
+        verify(repository, times(1))
+                .findOwner(source.getId());
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new SearchRecipeResponseBody and populate owner and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewSearchRecipeResponseBodyAndPopulatesOwnerAndReturnsIt() {
+        final Recipe source = repository.findAll().getFirst();
+        final SearchRecipeResponseBody searchRecipeResponseBody = mapper.mapToDTO(source);
+        assertEquals(source.getId(), searchRecipeResponseBody.getId());
+        assertEquals(source.getName(), searchRecipeResponseBody.getName());
+        assertEquals(source.getDescription(), searchRecipeResponseBody.getDescription());
+        assertEquals(source.getDifficulty(), searchRecipeResponseBody.getDifficulty());
+        equalCategories(source, searchRecipeResponseBody);
+        equalIngredients(source, searchRecipeResponseBody);
+        assertEquals(source.getServings(), searchRecipeResponseBody.getServings());
+        assertEquals(source.getCookingTime(), searchRecipeResponseBody.getCookingTime());
+        assertEquals(source.getInstructions(), searchRecipeResponseBody.getInstructions());
+        verify(repository, times(1))
+                .findOwner(source.getId());
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+
+    private static void equalCategories(Recipe source, SearchRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getCategories()
+                        .stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList(),
+                target.getCategories()
+                        .stream()
+                        .sorted()
+                        .toList()
+        );
+    }
+
+    private static void equalIngredients(Recipe source, SearchRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getUnit)
+                        .sorted()
+                        .toList()
+        );
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/integration/repository/RecipeRepositoryV3IntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/repository/RecipeRepositoryV3IntegrationTest.java
@@ -1,0 +1,103 @@
+package com.askie01.recipeapplication.integration.repository;
+
+import com.askie01.recipeapplication.repository.CustomerRepositoryV1;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.annotation.DirtiesContext;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("RecipeRepositoryV3 integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class RecipeRepositoryV3IntegrationTest {
+
+    private final RecipeRepositoryV3 recipeRepository;
+    private final CustomerRepositoryV1 customerRepository;
+
+    @Test
+    @DisplayName("findByUsername when username exists returns page of customer recipes")
+    void findByUsername_whenUsernameExists_returnsCustomerRecipePage() {
+        final String username = customerRepository.findAll().stream().findAny().orElseThrow().getUsername();
+        final Pageable pageable = PageRequest.of(0, 10);
+        final boolean recipesExist = recipeRepository
+                .findByUsername(username, pageable)
+                .getTotalElements() != 0;
+        assertTrue(recipesExist);
+    }
+
+    @Test
+    @DisplayName("findByUsername when username does not exist returns empty page")
+    void findByUsername_whenUsernameDoesNotExist_returnsEmptyPage() {
+        final String nonExistingUsername = "non-existing-username";
+        final Pageable pageable = PageRequest.of(0, 10);
+        final boolean recipesExist = recipeRepository
+                .findByUsername(nonExistingUsername, pageable)
+                .getTotalElements() == 0;
+        assertTrue(recipesExist);
+    }
+
+    @Test
+    @DisplayName("searchRecipes when query exists returns page of recipes")
+    void searchRecipes_whenQueryExists_returnsRecipesPage() {
+        final String query = recipeRepository.findAll().stream().findAny().orElseThrow().getName();
+        final Pageable pageable = PageRequest.of(0, 10);
+        final boolean recipesExist = recipeRepository
+                .searchRecipes(query, pageable)
+                .getTotalElements() != 0;
+        assertTrue(recipesExist);
+    }
+
+    @Test
+    @DisplayName("searchRecipes when query does not exist returns empty page")
+    void searchRecipes_whenQueryDoesNotExist_returnsEmptyPage() {
+        final String query = "non-existing-query";
+        final Pageable pageable = PageRequest.of(0, 10);
+        final boolean recipesExist = recipeRepository
+                .searchRecipes(query, pageable)
+                .getTotalElements() == 0;
+        assertTrue(recipesExist);
+    }
+
+    @Test
+    @DisplayName("findOwner when recipeId exists returns recipe owner")
+    void findOwner_whenRecipeIdExists_returnsRecipeOwner() {
+        final Long id = recipeRepository.findAll().stream().findAny().orElseThrow().getId();
+        final boolean ownerExists = recipeRepository.findOwner(id).isPresent();
+        assertTrue(ownerExists);
+    }
+
+    @Test
+    @DisplayName("findOwner when recipeId does not exist returns empty optional")
+    void findOwner_whenRecipeIdDoesNotExists_returnsEmptyOptional() {
+        final Long id = Long.MAX_VALUE;
+        final boolean ownerExists = recipeRepository.findOwner(id).isPresent();
+        assertFalse(ownerExists);
+    }
+
+    @Test
+    @DisplayName("findRecipeImage when recipeId exists returns recipe image")
+    void findRecipeImage_whenRecipeIdExists_returnsRecipeImage() {
+        final Long id = recipeRepository.findAll().stream().findAny().orElseThrow().getId();
+        final boolean imageExists = recipeRepository.findRecipeImage(id).isPresent();
+        assertTrue(imageExists);
+    }
+
+    @Test
+    @DisplayName("findRecipeImage when recipeId does not exist returns empty optional")
+    void findRecipeImage_whenRecipeIdDoesNotExists_returnsEmptyOptional() {
+        final Long id = Long.MAX_VALUE;
+        final boolean imageExists = recipeRepository.findRecipeImage(id).isPresent();
+        assertFalse(imageExists);
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/integration/service/DefaultRecipeServiceV3IntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/service/DefaultRecipeServiceV3IntegrationTest.java
@@ -1,0 +1,326 @@
+package com.askie01.recipeapplication.integration.service;
+
+import com.askie01.recipeapplication.configuration.CustomerRecipeRequestBodyToRecipeMapperConfiguration;
+import com.askie01.recipeapplication.configuration.JpaAuditingConfiguration;
+import com.askie01.recipeapplication.configuration.RecipeServiceV3Configuration;
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.dto.IngredientRequestBody;
+import com.askie01.recipeapplication.exception.RecipeNotFoundException;
+import com.askie01.recipeapplication.mapper.CustomerRecipeRequestBodyToRecipeMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.CustomerRepositoryV1;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import com.askie01.recipeapplication.service.RecipeServiceV3;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Import(value = {
+        RecipeServiceV3Configuration.class,
+        CustomerRecipeRequestBodyToRecipeMapperConfiguration.class,
+        JpaAuditingConfiguration.class
+})
+@TestPropertySource(properties = {
+        "component.service.recipe-v3=default",
+        "component.mapper.customer-recipe-request-body-to-recipe-type=default",
+        "component.auditor-type=recipe-service-auditor"
+})
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("DefaultRecipeServiceV3 integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class DefaultRecipeServiceV3IntegrationTest {
+
+    private final RecipeServiceV3 service;
+
+    @MockitoSpyBean
+    private final RecipeRepositoryV3 recipeRepository;
+
+    @MockitoSpyBean
+    private final CustomerRepositoryV1 customerRepository;
+
+    @MockitoSpyBean
+    private final CustomerRecipeRequestBodyToRecipeMapper mapper;
+    private CustomerRecipeRequestBody requestBody;
+
+    @BeforeEach
+    void setUp() {
+        this.requestBody = getTestCustomerRecipeRequestBody();
+    }
+
+    private static CustomerRecipeRequestBody getTestCustomerRecipeRequestBody() {
+        return CustomerRecipeRequestBody.builder()
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientRequestBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientRequestBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("createRecipe method should create recipe when username and request body are present")
+    void createRecipe_whenUsername_andRequestBodyArePresent_createsRecipe() {
+        final String username = customerRepository.findAll().getFirst().getUsername();
+        service.createRecipe(username, requestBody);
+        verify(customerRepository, times(1))
+                .findByUsernameIgnoreCase(any(String.class));
+        verify(mapper, times(1))
+                .mapToEntity(any(CustomerRecipeRequestBody.class));
+        verify(customerRepository, times(1))
+                .save(any(Customer.class));
+    }
+
+    @Test
+    @DisplayName("createRecipe method should throw UsernameNotFoundException when username is null")
+    void createRecipe_whenUsernameIsNull_throwsUsernameNotFoundException() {
+        assertThrows(UsernameNotFoundException.class, () -> service.createRecipe(null, requestBody));
+    }
+
+    @Test
+    @DisplayName("createRecipe method should throw NullPointerException when request body is null")
+    void createRecipe_whenRequestBodyIsNull_throwsNullPointerException() {
+        final String username = customerRepository.findAll().getFirst().getUsername();
+        assertThrows(NullPointerException.class, () -> service.createRecipe(username, null));
+    }
+
+    @Test
+    @DisplayName("getRecipe method should return recipe with given id when recipe with that id exists")
+    void getRecipe_whenRecipeIdExists_returnsRecipeWithThatId() {
+        final Long id = recipeRepository.findAll().getFirst().getId();
+        final Recipe recipe = service.getRecipe(id);
+        assertNotNull(recipe);
+    }
+
+    @Test
+    @DisplayName("getRecipe method should throw RecipeNotFoundException when recipe with given id does not exist")
+    void getRecipe_whenRecipeIdDoesNotExist_throwsRecipeNotFoundException() {
+        final Long id = Long.MAX_VALUE;
+        assertThrows(RecipeNotFoundException.class, () -> service.getRecipe(id));
+    }
+
+    @Test
+    @DisplayName("getRecipeImage method should return recipe image when recipe with given id exists")
+    void getRecipeImage_whenRecipeIdExists_returnsRecipeImage() {
+        final Long id = recipeRepository.findAll().getFirst().getId();
+        final byte[] image = service.getRecipeImage(id);
+        assertNotNull(image);
+    }
+
+    @Test
+    @DisplayName("getRecipeImage method should throw RecipeNotFoundException when recipe with given id does not exist")
+    void getRecipeImage_whenRecipeIdDoesNotExist_throwsRecipeNotFoundException() {
+        final Long id = Long.MAX_VALUE;
+        assertThrows(RecipeNotFoundException.class, () -> service.getRecipeImage(id));
+    }
+
+    @Test
+    @DisplayName("getCustomerRecipes method should return recipes page when username exists")
+    void getCustomerRecipes_whenUsernameExists_returnsRecipesPage() {
+        final String username = customerRepository.findAll().getFirst().getUsername();
+        final boolean pageIsNotEmpty = service
+                .getCustomerRecipes(username, PageRequest.of(0, 10))
+                .getTotalElements() != 0;
+        assertTrue(pageIsNotEmpty);
+    }
+
+    @Test
+    @DisplayName("getCustomerRecipes method should return empty recipes page when username does not exist")
+    void getCustomerRecipes_whenUsernameDoesNotExist_returnsEmptyRecipesPage() {
+        final String username = "non-existing-username";
+        final boolean pageIsEmpty = service
+                .getCustomerRecipes(username, PageRequest.of(0, 10))
+                .getTotalElements() == 0;
+        assertTrue(pageIsEmpty);
+    }
+
+    @Test
+    @DisplayName("searchRecipes method should return recipes page when query matches recipes")
+    void searchRecipes_whenQueryMatchesRecipes_returnsRecipesPage() {
+        final String query = recipeRepository.findAll().getFirst().getName();
+        final boolean pageIsNotEmpty = service
+                .searchRecipes(query, PageRequest.of(0, 10))
+                .getTotalElements() != 0;
+        assertTrue(pageIsNotEmpty);
+    }
+
+    @Test
+    @DisplayName("searchRecipes method should return empty recipes page when query does not match recipes")
+    void searchRecipes_whenQueryDoesNotMatchRecipes_returnsEmptyRecipesPage() {
+        final String query = "non-existing-query";
+        final boolean pageIsEmpty = service
+                .searchRecipes(query, PageRequest.of(0, 10))
+                .getTotalElements() == 0;
+        assertTrue(pageIsEmpty);
+    }
+
+    @Test
+    @DisplayName("updateRecipe method should update recipe when username, recipeId and request body are present")
+    void updateRecipe_whenUsername_andRecipeId_andRequestBodyArePresent_updatesRecipe() {
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        service.updateRecipe(username, recipeId, requestBody);
+        verify(customerRepository, times(1))
+                .findByUsernameIgnoreCase(any(String.class));
+        verify(mapper, times(1))
+                .map(any(CustomerRecipeRequestBody.class), any(Recipe.class));
+        verify(recipeRepository, times(1))
+                .save(any(Recipe.class));
+    }
+
+    @Test
+    @DisplayName("updateRecipe method should throw UsernameNotFoundException when username does not exist")
+    void updateRecipe_whenUsernameDoesNotExist_throwsUsernameNotFoundException() {
+        final String username = "non-existing-username";
+        assertThrows(UsernameNotFoundException.class, () -> service.updateRecipe(username, 1L, requestBody));
+    }
+
+    @Test
+    @DisplayName("updateRecipe method should throw RecipeNotFoundException when recipeId does not belong to customer")
+    void updateRecipe_whenRecipeIdDoesNotBelongToCustomer_throwsRecipeNotFoundException() {
+        final String username = customerRepository.findAll().getFirst().getUsername();
+        final Long recipeId = Long.MAX_VALUE;
+        assertThrows(RecipeNotFoundException.class, () -> service.updateRecipe(username, recipeId, requestBody));
+    }
+
+    @Test
+    @DisplayName("updateRecipe method should throw NullPointerException when request body is null")
+    void updateRecipe_whenRequestBodyIsNull_throwsNullPointerException() {
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        assertThrows(NullPointerException.class, () -> service.updateRecipe(username, recipeId, null));
+        verify(customerRepository, times(1))
+                .findByUsernameIgnoreCase(any(String.class));
+        verify(mapper, times(1))
+                .map(isNull(), any(Recipe.class));
+        verify(recipeRepository, never())
+                .save(any(Recipe.class));
+    }
+
+    @Test
+    @DisplayName("updateImage method should update image when username, recipeId and image are present")
+    void updateImage_whenUsername_andRecipeId_andImageArePresent_updatesImage() {
+        final MultipartFile image = new MockMultipartFile("Image", "new-image.jpg", "image/jpeg", new byte[20]);
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        service.updateImage(username, recipeId, image);
+        verify(customerRepository, times(1))
+                .findByUsernameIgnoreCase(any(String.class));
+        verify(recipeRepository, times(1))
+                .save(any(Recipe.class));
+    }
+
+    @Test
+    @DisplayName("updateImage method should throw UsernameNotFoundException when username does not exist")
+    void updateImage_whenUsernameDoesNotExist_throwsUsernameNotFoundException() {
+        final MultipartFile image = new MockMultipartFile("Image", "new-image.jpg", "image/jpeg", new byte[20]);
+        final String username = "non-existing-username";
+        assertThrows(UsernameNotFoundException.class, () -> service.updateImage(username, 1L, image));
+    }
+
+    @Test
+    @DisplayName("updateImage method should throw RecipeNotFoundException when recipeId does not belong to customer")
+    void updateImage_whenRecipeIdDoesNotBelongToCustomer_throwsRecipeNotFoundException() {
+        final String username = customerRepository.findAll().getFirst().getUsername();
+        final Long recipeId = Long.MAX_VALUE;
+        final MultipartFile image = new MockMultipartFile("Image", "new-image.jpg", "image/jpeg", new byte[20]);
+        assertThrows(RecipeNotFoundException.class, () -> service.updateImage(username, recipeId, image));
+    }
+
+    @Test
+    @DisplayName("updateImage method should throw IllegalArgumentException when image is not in correct format")
+    void updateImage_whenImageIsIncorrectFormat_throwsIllegalArgumentException() {
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        final MultipartFile notImage = new MockMultipartFile("Image", "not-image.txt", "text/plain", new byte[20]);
+        assertThrows(IllegalArgumentException.class, () -> service.updateImage(username, recipeId, notImage));
+    }
+
+    @Test
+    @DisplayName("restoreDefaultImage method should restore default image when username and recipeId are present")
+    void restoreDefaultImage_whenUsername_andRecipeIdArePresent_restoresDefaultRecipeImage() {
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        service.restoreDefaultImage(username, recipeId);
+        verify(recipeRepository, times(1))
+                .save(any(Recipe.class));
+    }
+
+    @Test
+    @DisplayName("restoreDefaultImage method should throw UsernameNotFoundException when username does not exist")
+    void restoreDefaultImage_whenUsernameDoesNotExist_throwsUsernameNotFoundException() {
+        final String username = "non-existing-username";
+        assertThrows(UsernameNotFoundException.class, () -> service.restoreDefaultImage(username, 1L));
+    }
+
+    @Test
+    @DisplayName("restoreDefaultImage method should throw RecipeNotFoundException when recipeId does not belong to customer")
+    void restoreDefaultImage_whenRecipeIdDoesNotBelongToCustomer_throwsRecipeNotFoundException() {
+        final String username = customerRepository.findAll().getFirst().getUsername();
+        final Long recipeId = Long.MAX_VALUE;
+        assertThrows(RecipeNotFoundException.class, () -> service.restoreDefaultImage(username, recipeId));
+    }
+
+    @Test
+    @DisplayName("deleteRecipe method should delete recipe when username and recipeId are present")
+    void deleteRecipe_whenUsername_andRecipeIdArePresent_deletesRecipe() {
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        service.deleteRecipe(username, recipeId);
+        verify(customerRepository, times(1))
+                .save(any(Customer.class));
+    }
+
+    @Test
+    @DisplayName("deleteRecipe method should throw UsernameNotFoundException when username does not exist")
+    void deleteRecipe_whenUsernameDoesNotExist_throwsUsernameNotFoundException() {
+        final String username = "non-existing-username";
+        assertThrows(UsernameNotFoundException.class, () -> service.deleteRecipe(username, 1L));
+    }
+
+    @Test
+    @DisplayName("deleteRecipe method should throw RecipeNotFoundException when recipeId does not belong to customer")
+    void deleteRecipe_whenRecipeIdDoesNotBelongToCustomer_throwsRecipeNotFoundException() {
+        final String username = customerRepository.findAll().getFirst().getUsername();
+        final Long recipeId = Long.MAX_VALUE;
+        assertThrows(RecipeNotFoundException.class, () -> service.deleteRecipe(username, recipeId));
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultCustomerRecipeRequestBodyToRecipeMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultCustomerRecipeRequestBodyToRecipeMapperUnitTest.java
@@ -1,0 +1,218 @@
+package com.askie01.recipeapplication.unit.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.dto.IngredientRequestBody;
+import com.askie01.recipeapplication.mapper.CustomerRecipeRequestBodyToRecipeMapper;
+import com.askie01.recipeapplication.mapper.DefaultCustomerRecipeRequestBodyToRecipeMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("DefaultCustomerRecipeRequestBodyToRecipeMapper unit tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "unit")
+class DefaultCustomerRecipeRequestBodyToRecipeMapperUnitTest {
+
+    private CustomerRecipeRequestBody source;
+    private Recipe target;
+    private CustomerRecipeRequestBodyToRecipeMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestCustomerRecipeRequestBody();
+        this.target = getTestRecipe();
+        this.mapper = new DefaultCustomerRecipeRequestBodyToRecipeMapper();
+    }
+
+    private static CustomerRecipeRequestBody getTestCustomerRecipeRequestBody() {
+        return CustomerRecipeRequestBody.builder()
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientRequestBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientRequestBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(2L)
+                .name("Test category")
+                .version(2L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(2L)
+                .name("Test measure unit")
+                .version(2L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(2L)
+                .name("Test ingredient")
+                .amount(2.0)
+                .measureUnit(measureUnit)
+                .version(2L)
+                .build();
+        return Recipe.builder()
+                .id(2L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test instructions in Recipe")
+                .version(2L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        final String sourceName = source.getName();
+        final String targetName = target.getName();
+        assertEquals(sourceName, targetName);
+
+        final String sourceDescription = source.getDescription();
+        final String targetDescription = target.getDescription();
+        assertEquals(sourceDescription, targetDescription);
+
+        final Difficulty sourceDifficulty = source.getDifficulty();
+        final Difficulty targetDifficulty = target.getDifficulty();
+        assertEquals(sourceDifficulty, targetDifficulty);
+
+        equalCategories(source, target);
+        equalIngredients(source, target);
+
+        final Double sourceServings = source.getServings();
+        final Double targetServings = target.getServings();
+        assertEquals(sourceServings, targetServings);
+
+        final Integer sourceCookingTime = source.getCookingTime();
+        final Integer targetCookingTime = target.getCookingTime();
+        assertEquals(sourceCookingTime, targetCookingTime);
+
+        final String sourceInstructions = source.getInstructions();
+        final String targetInstructions = target.getInstructions();
+        assertEquals(sourceInstructions, targetInstructions);
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should map all common fields from source to new Recipe and return it")
+    void mapToEntity_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewRecipeAndReturnIt() {
+        final Recipe recipe = mapper.mapToEntity(source);
+        final String sourceName = source.getName();
+        final String recipeName = recipe.getName();
+        assertEquals(sourceName, recipeName);
+
+        final String sourceDescription = source.getDescription();
+        final String recipeDescription = recipe.getDescription();
+        assertEquals(sourceDescription, recipeDescription);
+
+        final Difficulty sourceDifficulty = source.getDifficulty();
+        final Difficulty recipeDifficulty = recipe.getDifficulty();
+        assertEquals(sourceDifficulty, recipeDifficulty);
+
+        equalCategories(source, recipe);
+        equalIngredients(source, recipe);
+
+        final Double sourceServings = source.getServings();
+        final Double recipeServings = recipe.getServings();
+        assertEquals(sourceServings, recipeServings);
+
+        final Integer sourceCookingTime = source.getCookingTime();
+        final Integer recipeCookingTime = recipe.getCookingTime();
+        assertEquals(sourceCookingTime, recipeCookingTime);
+
+        final String sourceInstructions = source.getInstructions();
+        final String recipeInstructions = recipe.getInstructions();
+        assertEquals(sourceInstructions, recipeInstructions);
+    }
+
+    @Test
+    @DisplayName("mapToEntity method should throw NullPointerException when source is null")
+    void mapToEntity_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToEntity(null));
+    }
+
+    private static void equalCategories(CustomerRecipeRequestBody source, Recipe target) {
+        assertIterableEquals(
+                source.getCategories().stream()
+                        .sorted()
+                        .toList(),
+                target.getCategories().stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList()
+        );
+    }
+
+    private static void equalIngredients(CustomerRecipeRequestBody source, Recipe target) {
+        assertIterableEquals(
+                source.getIngredients().stream()
+                        .map(IngredientRequestBody::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients().stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients().stream()
+                        .map(IngredientRequestBody::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients().stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients().stream()
+                        .map(IngredientRequestBody::getUnit)
+                        .sorted()
+                        .toList(),
+                target.getIngredients().stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList()
+        );
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultRecipeToCustomerRecipeResponseBodyMapperUnitTest.java
@@ -1,0 +1,208 @@
+package com.askie01.recipeapplication.unit.mapper;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeResponseBody;
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.mapper.DefaultRecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToCustomerRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("DefaultRecipeToCustomerRecipeResponseBodyMapper unit tests")
+@EnabledIfSystemProperty(named = "test.unit", matches = "true")
+class DefaultRecipeToCustomerRecipeResponseBodyMapperUnitTest {
+
+    private Recipe source;
+    private CustomerRecipeResponseBody target;
+    private RecipeToCustomerRecipeResponseBodyMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestRecipe();
+        this.target = getTestCustomerRecipeResponseBody();
+        this.mapper = new DefaultRecipeToCustomerRecipeResponseBodyMapper();
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(1L)
+                .name("Test category")
+                .version(1L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(1L)
+                .name("Test measure unit")
+                .version(1L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(1L)
+                .name("Test ingredient")
+                .amount(1.0)
+                .measureUnit(measureUnit)
+                .version(1L)
+                .build();
+        return Recipe.builder()
+                .id(1L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(1.0)
+                .cookingTime(10)
+                .instructions("Test instructions in Recipe")
+                .version(1L)
+                .build();
+    }
+
+    private static CustomerRecipeResponseBody getTestCustomerRecipeResponseBody() {
+        return CustomerRecipeResponseBody.builder()
+                .id(2L)
+                .name("Test customer recipe")
+                .description("Test customer description")
+                .difficulty(Difficulty.MEDIUM)
+                .categories(new HashSet<>(Set.of("Test customer category")))
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientResponseBody("Test customer ingredient", 1.0, "Test customer unit")
+                )))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test customer instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTarget() {
+        mapper.map(source, target);
+        assertEquals(source.getId(), target.getId());
+        assertEquals(source.getName(), target.getName());
+        assertEquals(source.getDescription(), target.getDescription());
+        equalCategories(source, target);
+        equalIngredients(source, target);
+        assertEquals(source.getServings(), target.getServings());
+        assertEquals(source.getCookingTime(), target.getCookingTime());
+        assertEquals(source.getInstructions(), target.getInstructions());
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new CustomerRecipeResponseBody and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewCustomerRecipeResponseBodyAndReturnIt() {
+        final CustomerRecipeResponseBody customerRecipeResponseBody = mapper.mapToDTO(source);
+        final Long sourceId = source.getId();
+        final Long customerRecipeResponseBodyId = customerRecipeResponseBody.getId();
+        assertEquals(sourceId, customerRecipeResponseBodyId);
+
+        final String sourceName = source.getName();
+        final String customerRecipeResponseBodyName = customerRecipeResponseBody.getName();
+        assertEquals(sourceName, customerRecipeResponseBodyName);
+
+        final String sourceDescription = source.getDescription();
+        final String customerRecipeResponseBodyDescription = customerRecipeResponseBody.getDescription();
+        assertEquals(sourceDescription, customerRecipeResponseBodyDescription);
+
+        final Difficulty sourceDifficulty = source.getDifficulty();
+        final Difficulty customerRecipeResponseBodyDifficulty = customerRecipeResponseBody.getDifficulty();
+        assertEquals(sourceDifficulty, customerRecipeResponseBodyDifficulty);
+
+        equalCategories(source, customerRecipeResponseBody);
+        equalIngredients(source, customerRecipeResponseBody);
+
+        final Double sourceServings = source.getServings();
+        final Double customerRecipeResponseBodyServings = customerRecipeResponseBody.getServings();
+        assertEquals(sourceServings, customerRecipeResponseBodyServings);
+
+        final Integer sourceCookingTime = source.getCookingTime();
+        final Integer customerRecipeResponseBodyCookingTime = customerRecipeResponseBody.getCookingTime();
+        assertEquals(sourceCookingTime, customerRecipeResponseBodyCookingTime);
+
+        final String sourceInstructions = source.getInstructions();
+        final String customerRecipeResponseBodyInstructions = customerRecipeResponseBody.getInstructions();
+        assertEquals(sourceInstructions, customerRecipeResponseBodyInstructions);
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+
+    private static void equalCategories(Recipe source, CustomerRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getCategories()
+                        .stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList(),
+                target.getCategories()
+                        .stream()
+                        .sorted()
+                        .toList());
+    }
+
+    private static void equalIngredients(Recipe source, CustomerRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getUnit)
+                        .sorted()
+                        .toList()
+        );
+    }
+}

--- a/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultRecipeToSearchRecipeResponseBodyMapperUnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/mapper/DefaultRecipeToSearchRecipeResponseBodyMapperUnitTest.java
@@ -1,0 +1,215 @@
+package com.askie01.recipeapplication.unit.mapper;
+
+import com.askie01.recipeapplication.dto.IngredientResponseBody;
+import com.askie01.recipeapplication.dto.SearchRecipeResponseBody;
+import com.askie01.recipeapplication.mapper.DefaultRecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.mapper.RecipeToSearchRecipeResponseBodyMapper;
+import com.askie01.recipeapplication.model.entity.Category;
+import com.askie01.recipeapplication.model.entity.Ingredient;
+import com.askie01.recipeapplication.model.entity.MeasureUnit;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DefaultRecipeToSearchRecipeResponseBodyMapper unit tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "unit")
+class DefaultRecipeToSearchRecipeResponseBodyMapperUnitTest {
+
+    private Recipe source;
+    private SearchRecipeResponseBody target;
+    private RecipeToSearchRecipeResponseBodyMapper mapper;
+
+    @Mock
+    private RecipeRepositoryV3 repository;
+
+    @BeforeEach
+    void setUp() {
+        this.source = getTestRecipe();
+        this.target = getTestSearchRecipeResponseBody();
+        this.mapper = new DefaultRecipeToSearchRecipeResponseBodyMapper(repository);
+    }
+
+    private static Recipe getTestRecipe() {
+        final Category category = Category.builder()
+                .id(2L)
+                .name("Test category")
+                .version(2L)
+                .build();
+        final MeasureUnit measureUnit = MeasureUnit.builder()
+                .id(2L)
+                .name("Test measure unit")
+                .version(2L)
+                .build();
+        final Ingredient ingredient = Ingredient.builder()
+                .id(2L)
+                .name("Test ingredient")
+                .amount(2.0)
+                .measureUnit(measureUnit)
+                .version(2L)
+                .build();
+        return Recipe.builder()
+                .id(2L)
+                .name("Test recipe")
+                .image(new byte[48])
+                .description("Test description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(category)))
+                .ingredients(new HashSet<>(Set.of(ingredient)))
+                .servings(2.0)
+                .cookingTime(20)
+                .instructions("Test instructions in Recipe")
+                .version(2L)
+                .build();
+    }
+
+    private static SearchRecipeResponseBody getTestSearchRecipeResponseBody() {
+        return SearchRecipeResponseBody.builder()
+                .owner("Test owner")
+                .id(1L)
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientResponseBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientResponseBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("map method should map all common fields from source to target and populates owner")
+    void map_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToTargetAndPopulatesOwner() {
+        when(repository.findOwner(any(Long.class)))
+                .thenReturn(Optional.of("Test owner"));
+
+        mapper.map(source, target);
+        assertEquals(source.getId(), target.getId());
+        assertEquals(source.getName(), target.getName());
+        assertEquals(source.getDescription(), target.getDescription());
+        assertEquals(source.getDifficulty(), target.getDifficulty());
+        equalCategories(source, target);
+        equalIngredients(source, target);
+        assertEquals(source.getServings(), target.getServings());
+        assertEquals(source.getCookingTime(), target.getCookingTime());
+        assertEquals(source.getInstructions(), target.getInstructions());
+        verify(repository, times(1))
+                .findOwner(source.getId());
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when source is null")
+    void map_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(null, target));
+    }
+
+    @Test
+    @DisplayName("map method should throw NullPointerException when target is null")
+    void map_whenTargetIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.map(source, null));
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should map all common fields from source to new SearchRecipeResponseBody and populate owner and return it")
+    void mapToDTO_whenSourceIsPresent_mapsAllCommonFieldsFromSourceToNewSearchRecipeResponseBodyAndPopulatesOwnerAndReturnsIt() {
+        when(repository.findOwner(any(Long.class)))
+                .thenReturn(Optional.of("Test owner"));
+        final SearchRecipeResponseBody searchRecipeResponseBody = mapper.mapToDTO(source);
+        assertEquals(source.getId(), searchRecipeResponseBody.getId());
+        assertEquals(source.getName(), searchRecipeResponseBody.getName());
+        assertEquals(source.getDescription(), searchRecipeResponseBody.getDescription());
+        assertEquals(source.getDifficulty(), searchRecipeResponseBody.getDifficulty());
+        equalCategories(source, searchRecipeResponseBody);
+        equalIngredients(source, searchRecipeResponseBody);
+        assertEquals(source.getServings(), searchRecipeResponseBody.getServings());
+        assertEquals(source.getCookingTime(), searchRecipeResponseBody.getCookingTime());
+        assertEquals(source.getInstructions(), searchRecipeResponseBody.getInstructions());
+        verify(repository, times(1))
+                .findOwner(source.getId());
+    }
+
+    @Test
+    @DisplayName("mapToDTO method should throw NullPointerException when source is null")
+    void mapToDTO_whenSourceIsNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapToDTO(null));
+    }
+
+    private static void equalCategories(Recipe source, SearchRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getCategories()
+                        .stream()
+                        .map(Category::getName)
+                        .sorted()
+                        .toList(),
+                target.getCategories()
+                        .stream()
+                        .sorted()
+                        .toList()
+        );
+    }
+
+    private static void equalIngredients(Recipe source, SearchRecipeResponseBody target) {
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getName)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getAmount)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getAmount)
+                        .sorted()
+                        .toList()
+        );
+
+        assertIterableEquals(
+                source.getIngredients()
+                        .stream()
+                        .map(Ingredient::getMeasureUnit)
+                        .map(MeasureUnit::getName)
+                        .sorted()
+                        .toList(),
+                target.getIngredients()
+                        .stream()
+                        .map(IngredientResponseBody::getUnit)
+                        .sorted()
+                        .toList()
+        );
+    }
+}
+

--- a/src/test/java/com/askie01/recipeapplication/unit/service/DefaultRecipeServiceV3UnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/service/DefaultRecipeServiceV3UnitTest.java
@@ -1,0 +1,392 @@
+package com.askie01.recipeapplication.unit.service;
+
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.dto.IngredientRequestBody;
+import com.askie01.recipeapplication.exception.RecipeNotFoundException;
+import com.askie01.recipeapplication.mapper.CustomerRecipeRequestBodyToRecipeMapper;
+import com.askie01.recipeapplication.model.entity.Customer;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.CustomerRepositoryV1;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import com.askie01.recipeapplication.service.DefaultRecipeServiceV3;
+import com.askie01.recipeapplication.service.RecipeServiceV3;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DefaultRecipeServiceV3 unit tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "unit")
+class DefaultRecipeServiceV3UnitTest {
+
+    private RecipeServiceV3 service;
+    private CustomerRecipeRequestBody requestBody;
+
+    @Mock
+    private RecipeRepositoryV3 recipeRepository;
+
+    @Mock
+    private CustomerRepositoryV1 customerRepository;
+
+    @Mock
+    private CustomerRecipeRequestBodyToRecipeMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.requestBody = getTestCustomerRecipeRequestBody();
+        this.service = new DefaultRecipeServiceV3(recipeRepository, customerRepository, mapper);
+    }
+
+    private static CustomerRecipeRequestBody getTestCustomerRecipeRequestBody() {
+        return CustomerRecipeRequestBody.builder()
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientRequestBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientRequestBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("createRecipe method should create recipe when username and request body are present")
+    void createRecipe_whenUsername_andRequestBodyArePresent_createsRecipe() {
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>())
+                .build();
+        final Recipe recipe = Recipe.builder()
+                .categories(new HashSet<>())
+                .ingredients(new HashSet<>())
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        when(mapper.mapToEntity(any(CustomerRecipeRequestBody.class)))
+                .thenReturn(recipe);
+
+        service.createRecipe("username", requestBody);
+        verify(customerRepository, times(1))
+                .findByUsernameIgnoreCase(any(String.class));
+        verify(mapper, times(1))
+                .mapToEntity(any(CustomerRecipeRequestBody.class));
+        verify(customerRepository, times(1))
+                .save(any(Customer.class));
+    }
+
+    @Test
+    @DisplayName("createRecipe method should throw UsernameNotFoundException when username is null")
+    void createRecipe_whenUsernameIsNull_throwsUsernameNotFoundException() {
+        when(customerRepository.findByUsernameIgnoreCase(isNull()))
+                .thenThrow(UsernameNotFoundException.class);
+        assertThrows(UsernameNotFoundException.class, () -> service.createRecipe(null, requestBody));
+    }
+
+    @Test
+    @DisplayName("createRecipe method should throw NullPointerException when request body is null")
+    void createRecipe_whenRequestBodyIsNull_throwsNullPointerException() {
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>())
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        when(mapper.mapToEntity(isNull()))
+                .thenThrow(NullPointerException.class);
+        assertThrows(NullPointerException.class, () -> service.createRecipe("username", null));
+    }
+
+    @Test
+    @DisplayName("getRecipe method should return recipe with given id when recipe with that id exists")
+    void getRecipe_whenRecipeIdExists_returnsRecipeWithThatId() {
+        when(recipeRepository.findById(any(Long.class)))
+                .thenReturn(Optional.of(new Recipe()));
+        final Recipe recipe = service.getRecipe(1L);
+        assertNotNull(recipe);
+    }
+
+    @Test
+    @DisplayName("getRecipe method should throw RecipeNotFoundException when recipe with given id does not exist")
+    void getRecipe_whenRecipeIdDoesNotExist_throwsRecipeNotFoundException() {
+        when(recipeRepository.findById(any(Long.class)))
+                .thenThrow(RecipeNotFoundException.class);
+        assertThrows(RecipeNotFoundException.class, () -> service.getRecipe(1L));
+    }
+
+    @Test
+    @DisplayName("getRecipeImage method should return recipe image when recipe with given id exists")
+    void getRecipeImage_whenRecipeIdExists_returnsRecipeImage() {
+        when(recipeRepository.findRecipeImage(any(Long.class)))
+                .thenReturn(Optional.of(new byte[24]));
+        final byte[] image = service.getRecipeImage(1L);
+        assertNotNull(image);
+    }
+
+    @Test
+    @DisplayName("getRecipeImage method should throw RecipeNotFoundException when recipe with given id does not exist")
+    void getRecipeImage_whenRecipeIdDoesNotExist_throwsRecipeNotFoundException() {
+        when(recipeRepository.findRecipeImage(any(Long.class)))
+                .thenThrow(RecipeNotFoundException.class);
+        assertThrows(RecipeNotFoundException.class, () -> service.getRecipeImage(1L));
+    }
+
+    @Test
+    @DisplayName("getCustomerRecipes method should return recipes page when username exists")
+    void getCustomerRecipes_whenUsernameExists_returnsRecipesPage() {
+        final Page<Recipe> recipesPage = new PageImpl<>(List.of(new Recipe()));
+        when(recipeRepository.findByUsername(any(String.class), any(Pageable.class)))
+                .thenReturn(recipesPage);
+        final boolean pageIsNotEmpty = service
+                .getCustomerRecipes("username", PageRequest.of(0, 10))
+                .getTotalElements() != 0;
+        assertTrue(pageIsNotEmpty);
+    }
+
+    @Test
+    @DisplayName("getCustomerRecipes method should return empty recipes page when username does not exist")
+    void getCustomerRecipes_whenUsernameDoesNotExist_returnsEmptyRecipesPage() {
+        when(recipeRepository.findByUsername(any(String.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+        final boolean pageIsEmpty = service
+                .getCustomerRecipes("username", PageRequest.of(0, 10))
+                .getTotalElements() == 0;
+        assertTrue(pageIsEmpty);
+    }
+
+    @Test
+    @DisplayName("searchRecipes method should return recipes page when query matches recipes")
+    void searchRecipes_whenQueryMatchesRecipes_returnsRecipesPage() {
+        final Page<Recipe> recipesPage = new PageImpl<>(List.of(new Recipe()));
+        when(recipeRepository.searchRecipes(any(String.class), any(Pageable.class)))
+                .thenReturn(recipesPage);
+        final boolean pageIsNotEmpty = service
+                .searchRecipes("query", PageRequest.of(0, 10))
+                .getTotalElements() != 0;
+        assertTrue(pageIsNotEmpty);
+    }
+
+    @Test
+    @DisplayName("searchRecipes method should return empty recipes page when query does not match recipes")
+    void searchRecipes_whenQueryDoesNotMatchRecipes_returnsEmptyRecipesPage() {
+        when(recipeRepository.searchRecipes(any(String.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+        final boolean pageIsEmpty = service
+                .searchRecipes("query", PageRequest.of(0, 10))
+                .getTotalElements() == 0;
+        assertTrue(pageIsEmpty);
+    }
+
+    @Test
+    @DisplayName("updateRecipe method should update recipe when username, recipeId and request body are present")
+    void updateRecipe_whenUsername_andRecipeId_andRequestBodyArePresent_updatesRecipe() {
+        final Recipe recipe = Recipe.builder()
+                .id(1L)
+                .build();
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>(List.of(recipe)))
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        service.updateRecipe("username", 1L, requestBody);
+        verify(customerRepository, times(1))
+                .findByUsernameIgnoreCase(any(String.class));
+        verify(mapper, times(1))
+                .map(any(CustomerRecipeRequestBody.class), any(Recipe.class));
+        verify(recipeRepository, times(1))
+                .save(any(Recipe.class));
+    }
+
+    @Test
+    @DisplayName("updateRecipe method should throw UsernameNotFoundException when username does not exist")
+    void updateRecipe_whenUsernameDoesNotExist_throwsUsernameNotFoundException() {
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenThrow(UsernameNotFoundException.class);
+        assertThrows(UsernameNotFoundException.class, () -> service.updateRecipe("username", 1L, requestBody));
+    }
+
+    @Test
+    @DisplayName("updateRecipe method should throw RecipeNotFoundException when recipeId does not belong to customer")
+    void updateRecipe_whenRecipeIdDoesNotBelongToCustomer_throwsRecipeNotFoundException() {
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>())
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        assertThrows(RecipeNotFoundException.class, () -> service.updateRecipe("username", 1L, requestBody));
+    }
+
+    @Test
+    @DisplayName("updateRecipe method should throw NullPointerException when request body is null")
+    void updateRecipe_whenRequestBodyIsNull_throwsNullPointerException() {
+        final Recipe recipe = Recipe.builder()
+                .id(1L)
+                .build();
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>(List.of(recipe)))
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        doThrow(NullPointerException.class)
+                .when(mapper)
+                .map(isNull(), any(Recipe.class));
+
+        assertThrows(NullPointerException.class, () -> service.updateRecipe("username", 1L, null));
+        verify(customerRepository, times(1))
+                .findByUsernameIgnoreCase(any(String.class));
+        verify(mapper, times(1))
+                .map(isNull(), any(Recipe.class));
+        verify(recipeRepository, never())
+                .save(any(Recipe.class));
+    }
+
+    @Test
+    @DisplayName("updateImage method should update image when username, recipeId and image are present")
+    void updateImage_whenUsername_andRecipeId_andImageArePresent_updatesImage() {
+        final Recipe recipe = Recipe.builder()
+                .id(1L)
+                .build();
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>(List.of(recipe)))
+                .build();
+        final MultipartFile image = new MockMultipartFile("Image", "new-image.jpg", "image/jpeg", new byte[20]);
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        service.updateImage("username", 1L, image);
+        verify(customerRepository, times(1))
+                .findByUsernameIgnoreCase(any(String.class));
+        verify(recipeRepository, times(1))
+                .save(any(Recipe.class));
+    }
+
+    @Test
+    @DisplayName("updateImage method should throw UsernameNotFoundException when username does not exist")
+    void updateImage_whenUsernameDoesNotExist_throwsUsernameNotFoundException() {
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenThrow(UsernameNotFoundException.class);
+        final MultipartFile image = new MockMultipartFile("Image", "new-image.jpg", "image/jpeg", new byte[20]);
+        assertThrows(UsernameNotFoundException.class, () -> service.updateImage("username", 1L, image));
+    }
+
+    @Test
+    @DisplayName("updateImage method should throw RecipeNotFoundException when recipeId does not belong to customer")
+    void updateImage_whenRecipeIdDoesNotBelongToCustomer_throwsRecipeNotFoundException() {
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>())
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        final MultipartFile image = new MockMultipartFile("Image", "new-image.jpg", "image/jpeg", new byte[20]);
+        assertThrows(RecipeNotFoundException.class, () -> service.updateImage("username", 1L, image));
+    }
+
+    @Test
+    @DisplayName("updateImage method should throw IllegalArgumentException when image is not in correct format")
+    void updateImage_whenImageIsIncorrectFormat_throwsIllegalArgumentException() {
+        final Recipe recipe = Recipe.builder()
+                .id(1L)
+                .build();
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>(List.of(recipe)))
+                .build();
+        final MultipartFile notImage = new MockMultipartFile("Image", "not-image.txt", "text/plain", new byte[20]);
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        assertThrows(IllegalArgumentException.class, () -> service.updateImage("username", 1L, notImage));
+    }
+
+    @Test
+    @DisplayName("restoreDefaultImage method should restore default image when username and recipeId are present")
+    void restoreDefaultImage_whenUsername_andRecipeIdArePresent_restoresDefaultRecipeImage() {
+        final Recipe recipe = Recipe.builder()
+                .id(1L)
+                .build();
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>(List.of(recipe)))
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        service.restoreDefaultImage("username", 1L);
+        verify(recipeRepository, times(1))
+                .save(any(Recipe.class));
+    }
+
+    @Test
+    @DisplayName("restoreDefaultImage method should throw UsernameNotFoundException when username does not exist")
+    void restoreDefaultImage_whenUsernameDoesNotExist_throwsUsernameNotFoundException() {
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenThrow(UsernameNotFoundException.class);
+        assertThrows(UsernameNotFoundException.class, () -> service.restoreDefaultImage("username", 1L));
+    }
+
+    @Test
+    @DisplayName("restoreDefaultImage method should throw RecipeNotFoundException when recipeId does not belong to customer")
+    void restoreDefaultImage_whenRecipeIdDoesNotBelongToCustomer_throwsRecipeNotFoundException() {
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>())
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        assertThrows(RecipeNotFoundException.class, () -> service.restoreDefaultImage("username", 1L));
+    }
+
+    @Test
+    @DisplayName("deleteRecipe method should delete recipe when username and recipeId are present")
+    void deleteRecipe_whenUsername_andRecipeIdArePresent_deletesRecipe() {
+        final Recipe recipe = Recipe.builder()
+                .id(1L)
+                .build();
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>(List.of(recipe)))
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        service.deleteRecipe("username", 1L);
+        verify(customerRepository, times(1))
+                .save(any(Customer.class));
+    }
+
+    @Test
+    @DisplayName("deleteRecipe method should throw UsernameNotFoundException when username does not exist")
+    void deleteRecipe_whenUsernameDoesNotExist_throwsUsernameNotFoundException() {
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenThrow(UsernameNotFoundException.class);
+        assertThrows(UsernameNotFoundException.class, () -> service.deleteRecipe("username", 1L));
+    }
+
+    @Test
+    @DisplayName("deleteRecipe method should throw RecipeNotFoundException when recipeId does not belong to customer")
+    void deleteRecipe_whenRecipeIdDoesNotBelongToCustomer_throwsRecipeNotFoundException() {
+        final Customer customer = Customer.builder()
+                .recipes(new HashSet<>())
+                .build();
+        when(customerRepository.findByUsernameIgnoreCase(any(String.class)))
+                .thenReturn(Optional.of(customer));
+        assertThrows(RecipeNotFoundException.class, () -> service.deleteRecipe("username", 1L));
+    }
+}


### PR DESCRIPTION
* Created `RecipeRestControllerV3` to receive incoming requests for Recipe API V3.
* Created integration tests to make sure this rest controller works as expected with close to real-world data.
* Added new property as configuration key in `additional-spring-configuration-metadata.json` to enable/disable Recipe API v3 on demand.
* Removed `equals()` & `hashCode()` methods in `Recipe` to rely on default implementations to avoid dirty hibernate context.
* Secured newly created endpoints in `SecurityFilterChainConfiguration` to increase API security.
* This pull request closes #535  