### PR TITLE
538 create logging aspect for recipe api v3

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/aspect/RecipeRestControllerV3LoggingAspect.java
+++ b/src/main/java/com/askie01/recipeapplication/aspect/RecipeRestControllerV3LoggingAspect.java
@@ -1,0 +1,266 @@
+package com.askie01.recipeapplication.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class RecipeRestControllerV3LoggingAspect {
+    private static final String CREATE_RECIPE_POINTCUT = "execution(* com.askie01.recipeapplication.api.*.RecipeRestControllerV3.createRecipe(..))";
+    private static final String GET_RECIPE_POINTCUT = "execution(* com.askie01.recipeapplication.api.*.RecipeRestControllerV3.getRecipe(..))";
+    private static final String GET_RECIPE_IMAGE_POINTCUT = "execution(* com.askie01.recipeapplication.api.*.RecipeRestControllerV3.getRecipeImage(..))";
+    private static final String GET_USER_RECIPES_POINTCUT = "execution(* com.askie01.recipeapplication.api.*.RecipeRestControllerV3.getUserRecipes(..))";
+    private static final String SEARCH_USER_RECIPES_POINTCUT = "execution(* com.askie01.recipeapplication.api.*.RecipeRestControllerV3.searchRecipes(..))";
+    private static final String UPDATE_RECIPE_DETAILS_POINTCUT = "execution(* com.askie01.recipeapplication.api.*.RecipeRestControllerV3.updateRecipeDetails(..))";
+    private static final String UPDATE_RECIPE_IMAGE_POINTCUT = "execution(* com.askie01.recipeapplication.api.*.RecipeRestControllerV3.updateRecipeImage(..))";
+    private static final String RESTORE_DEFAULT_RECIPE_IMAGE_POINTCUT = "execution(* com.askie01.recipeapplication.api.*.RecipeRestControllerV3.restoreDefaultRecipeImage(..))";
+    private static final String DELETE_RECIPE_POINTCUT = "execution(* com.askie01.recipeapplication.api.*.RecipeRestControllerV3.deleteRecipe(..))";
+
+    @Before(CREATE_RECIPE_POINTCUT)
+    public void logBeforeCreateRecipe(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final String requestBody = joinPoint.getArgs()[1].toString();
+        log.atInfo().log("Received createRecipe POST request with username: '{}' and request body: '{}'", username, requestBody);
+    }
+
+    @Around(CREATE_RECIPE_POINTCUT)
+    public Object logAndRethrowCreateRecipe(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        try {
+            return proceedingJoinPoint.proceed();
+        } catch (Exception exception) {
+            final Authentication authentication = (Authentication) proceedingJoinPoint.getArgs()[0];
+            final String username = authentication.getName();
+            final String requestBody = proceedingJoinPoint.getArgs()[1].toString();
+            log.atError().log("Error occurred while processing createRecipe POST request with username: '{}' and request body: '{}'", username, requestBody);
+            throw exception;
+        }
+    }
+
+    @After(CREATE_RECIPE_POINTCUT)
+    public void logAfterCreateRecipe(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final String requestBody = joinPoint.getArgs()[1].toString();
+        log.atInfo().log("Completed createRecipe POST request with username: '{}' and request body: '{}'", username, requestBody);
+    }
+
+    @Before(GET_RECIPE_POINTCUT)
+    public void logBeforeGetRecipe(JoinPoint joinPoint) {
+        final Long id = (Long) joinPoint.getArgs()[0];
+        log.atInfo().log("Received getRecipe GET request with ID: '{}'", id);
+    }
+
+    @Around(GET_RECIPE_POINTCUT)
+    public Object logAndRethrowGetRecipe(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        try {
+            return proceedingJoinPoint.proceed();
+        } catch (Exception exception) {
+            final Long id = (Long) proceedingJoinPoint.getArgs()[0];
+            log.atError().log("Error occurred while processing getRecipe GET request with ID: '{}'", id);
+            throw exception;
+        }
+    }
+
+    @After(GET_RECIPE_POINTCUT)
+    public void logAfterGetRecipe(JoinPoint joinPoint) {
+        final Long id = (Long) joinPoint.getArgs()[0];
+        log.atInfo().log("Completed getRecipe GET request with ID: '{}'", id);
+    }
+
+    @Before(GET_RECIPE_IMAGE_POINTCUT)
+    public void logBeforeGetRecipeImage(JoinPoint joinPoint) {
+        final Long id = (Long) joinPoint.getArgs()[0];
+        log.atInfo().log("Received getRecipeImage GET request with ID: '{}'", id);
+    }
+
+    @Around(GET_RECIPE_IMAGE_POINTCUT)
+    public Object logAndRethrowGetRecipeImage(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        try {
+            return proceedingJoinPoint.proceed();
+        } catch (Exception exception) {
+            final Long id = (Long) proceedingJoinPoint.getArgs()[0];
+            log.atError().log("Error occurred while processing getRecipeImage GET request with ID: '{}'", id);
+            throw exception;
+        }
+    }
+
+    @After(GET_RECIPE_IMAGE_POINTCUT)
+    public void logAfterGetRecipeImage(JoinPoint joinPoint) {
+        final Long id = (Long) joinPoint.getArgs()[0];
+        log.atInfo().log("Completed getRecipeImage GET request with ID: '{}'", id);
+    }
+
+    @Before(GET_USER_RECIPES_POINTCUT)
+    public void logBeforeGetUserRecipes(JoinPoint joinPoint) {
+        final String username = joinPoint.getArgs()[0].toString();
+        log.atInfo().log("Received getUserRecipes GET request with username: '{}'", username);
+    }
+
+    @Around(GET_USER_RECIPES_POINTCUT)
+    public Object logAndRethrowGetUserRecipes(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        try {
+            return proceedingJoinPoint.proceed();
+        } catch (Exception exception) {
+            final String username = proceedingJoinPoint.getArgs()[0].toString();
+            log.atError().log("Error occurred while processing getUserRecipes GET request with username: '{}'", username);
+            throw exception;
+        }
+    }
+
+    @After(GET_USER_RECIPES_POINTCUT)
+    public void logAfterGetUserRecipes(JoinPoint joinPoint) {
+        final String username = joinPoint.getArgs()[0].toString();
+        log.atInfo().log("Completed getUserRecipes GET request with username: '{}'", username);
+    }
+
+    @Before(SEARCH_USER_RECIPES_POINTCUT)
+    public void logBeforeSearchUserRecipes(JoinPoint joinPoint) {
+        final String query = joinPoint.getArgs()[0].toString();
+        log.atInfo().log("Received searchUserRecipes GET request with query: '{}'", query);
+    }
+
+    @Around(SEARCH_USER_RECIPES_POINTCUT)
+    public Object logAndRethrowSearchUserRecipes(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        try {
+            return proceedingJoinPoint.proceed();
+        } catch (Exception exception) {
+            final String query = proceedingJoinPoint.getArgs()[0].toString();
+            log.atError().log("Error occurred while processing searchUserRecipes GET request with query: '{}'", query);
+            throw exception;
+        }
+    }
+
+    @After(SEARCH_USER_RECIPES_POINTCUT)
+    public void logAfterSearchUserRecipes(JoinPoint joinPoint) {
+        final String query = joinPoint.getArgs()[0].toString();
+        log.atInfo().log("Completed searchUserRecipes GET request with query: '{}'", query);
+    }
+
+    @Before(UPDATE_RECIPE_DETAILS_POINTCUT)
+    public void logBeforeUpdateRecipeDetails(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final Long id = (Long) joinPoint.getArgs()[1];
+        final String requestBody = joinPoint.getArgs()[2].toString();
+        log.atInfo().log("Received updateRecipeDetails PUT request with username: '{}' and ID: '{}' and request body: '{}'", username, id, requestBody);
+    }
+
+    @Around(UPDATE_RECIPE_DETAILS_POINTCUT)
+    public Object logAndRethrowUpdateRecipeDetails(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        try {
+            return proceedingJoinPoint.proceed();
+        } catch (Exception exception) {
+            final Authentication authentication = (Authentication) proceedingJoinPoint.getArgs()[0];
+            final String username = authentication.getName();
+            final Long id = (Long) proceedingJoinPoint.getArgs()[1];
+            final String requestBody = proceedingJoinPoint.getArgs()[2].toString();
+            log.atError().log("Error occurred while processing updateRecipeDetails PUT request with username: '{}' and ID: '{}' and request body: '{}'", username, id, requestBody);
+            throw exception;
+        }
+    }
+
+    @After(UPDATE_RECIPE_DETAILS_POINTCUT)
+    public void logAfterUpdateRecipeDetails(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final Long id = (Long) joinPoint.getArgs()[1];
+        final String requestBody = joinPoint.getArgs()[2].toString();
+        log.atInfo().log("Completed updateRecipeDetails PUT request with username: '{}' and ID: '{}' and request body: '{}'", username, id, requestBody);
+    }
+
+    @Before(UPDATE_RECIPE_IMAGE_POINTCUT)
+    public void logBeforeUpdateRecipeImage(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final Long id = (Long) joinPoint.getArgs()[1];
+        log.atInfo().log("Received updateRecipeImage PUT request with username: '{}' and ID: '{}'", username, id);
+    }
+
+    @Around(UPDATE_RECIPE_IMAGE_POINTCUT)
+    public Object logAndRethrowUpdateRecipeImage(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        try {
+            return proceedingJoinPoint.proceed();
+        } catch (Exception exception) {
+            final Authentication authentication = (Authentication) proceedingJoinPoint.getArgs()[0];
+            final String username = authentication.getName();
+            final Long id = (Long) proceedingJoinPoint.getArgs()[1];
+            log.atError().log("Error occurred while processing updateRecipeImage PUT request with username: '{}' and ID: '{}'", username, id);
+            throw exception;
+        }
+    }
+
+    @After(UPDATE_RECIPE_IMAGE_POINTCUT)
+    public void logAfterUpdateRecipeImage(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final Long id = (Long) joinPoint.getArgs()[1];
+        log.atInfo().log("Completed updateRecipeImage PUT request with username: '{}' and ID: '{}'", username, id);
+    }
+
+    @Before(RESTORE_DEFAULT_RECIPE_IMAGE_POINTCUT)
+    public void logBeforeRestoreDefaultRecipeImage(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final Long id = (Long) joinPoint.getArgs()[1];
+        log.atInfo().log("Received restoreDefaultRecipeImage PUT request with username: '{}' and ID: '{}'", username, id);
+    }
+
+    @Around(RESTORE_DEFAULT_RECIPE_IMAGE_POINTCUT)
+    public Object logAndRethrowRestoreDefaultRecipeImage(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        try {
+            return proceedingJoinPoint.proceed();
+        } catch (Exception exception) {
+            final Authentication authentication = (Authentication) proceedingJoinPoint.getArgs()[0];
+            final String username = authentication.getName();
+            final Long id = (Long) proceedingJoinPoint.getArgs()[1];
+            log.atError().log("Error occurred while processing restoreDefaultRecipeImage PUT request with username: '{}' and ID: '{}'", username, id);
+            throw exception;
+        }
+    }
+
+    @After(RESTORE_DEFAULT_RECIPE_IMAGE_POINTCUT)
+    public void logAfterRestoreDefaultRecipeImage(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final Long id = (Long) joinPoint.getArgs()[1];
+        log.atInfo().log("Completed restoreDefaultRecipeImage PUT request with username: '{}' and ID: '{}'", username, id);
+    }
+
+    @Before(DELETE_RECIPE_POINTCUT)
+    public void logBeforeDeleteRecipe(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final Long id = (Long) joinPoint.getArgs()[1];
+        log.atInfo().log("Received deleteRecipe DELETE request with username: '{}' and ID: '{}'", username, id);
+    }
+
+    @Around(DELETE_RECIPE_POINTCUT)
+    public Object logAndRethrowDeleteRecipe(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        try {
+            return proceedingJoinPoint.proceed();
+        } catch (Exception exception) {
+            final Authentication authentication = (Authentication) proceedingJoinPoint.getArgs()[0];
+            final String username = authentication.getName();
+            final Long id = (Long) proceedingJoinPoint.getArgs()[1];
+            log.atError().log("Error occurred while processing deleteRecipe DELETE request with username: '{}' and ID: '{}'", username, id);
+            throw exception;
+        }
+    }
+
+    @After(DELETE_RECIPE_POINTCUT)
+    public void logAfterDeleteRecipe(JoinPoint joinPoint) {
+        final Authentication authentication = (Authentication) joinPoint.getArgs()[0];
+        final String username = authentication.getName();
+        final Long id = (Long) joinPoint.getArgs()[1];
+        log.atInfo().log("Completed deleteRecipe DELETE request with username: '{}' and ID: '{}'", username, id);
+    }
+}

--- a/src/main/java/com/askie01/recipeapplication/dto/CustomerRecipeRequestBody.java
+++ b/src/main/java/com/askie01/recipeapplication/dto/CustomerRecipeRequestBody.java
@@ -1,6 +1,8 @@
 package com.askie01.recipeapplication.dto;
 
 import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.util.Set;
@@ -13,12 +15,29 @@ import java.util.Set;
 @ToString
 @EqualsAndHashCode
 public class CustomerRecipeRequestBody {
+
+    @NotBlank(message = "Recipe name cannot be blank/null")
     private String name;
+
+    @NotBlank(message = "Recipe description cannot be blank/null")
     private String description;
+
+    @NotNull(message = "Recipe difficulty has to be EASY/MEDIUM/HARD")
     private Difficulty difficulty;
+
+    @NotEmpty(message = "Recipe categories cannot be empty")
     private Set<String> categories;
+
+    @Valid
+    @NotEmpty(message = "Recipe ingredients cannot be empty")
     private Set<IngredientRequestBody> ingredients;
+
+    @DecimalMin(value = "1.0", message = "Recipe servings have to be at least 1.0")
     private Double servings;
+
+    @PositiveOrZero(message = "Recipe cooking time have to be a positive or zero number")
     private Integer cookingTime;
+
+    @NotBlank(message = "Recipe instructions cannot be blank/null")
     private String instructions;
 }

--- a/src/test/java/com/askie01/recipeapplication/integration/api/v3/RecipeRestControllerV3IntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/api/v3/RecipeRestControllerV3IntegrationTest.java
@@ -129,7 +129,7 @@ class RecipeRestControllerV3IntegrationTest {
                 .body(new CustomerRecipeRequestBody())
                 .exchange()
                 .expectStatus()
-                .is5xxServerError();
+                .isBadRequest();
     }
 
     @Test
@@ -334,7 +334,7 @@ class RecipeRestControllerV3IntegrationTest {
                 .body(new CustomerRecipeRequestBody())
                 .exchange()
                 .expectStatus()
-                .is5xxServerError();
+                .isBadRequest();
     }
 
     @Test

--- a/src/test/java/com/askie01/recipeapplication/integration/aspect/RecipeRestControllerV3LoggingAspectIntegrationTest.java
+++ b/src/test/java/com/askie01/recipeapplication/integration/aspect/RecipeRestControllerV3LoggingAspectIntegrationTest.java
@@ -1,0 +1,424 @@
+package com.askie01.recipeapplication.integration.aspect;
+
+import com.askie01.recipeapplication.aspect.RecipeRestControllerV3LoggingAspect;
+import com.askie01.recipeapplication.dto.CustomerRecipeRequestBody;
+import com.askie01.recipeapplication.dto.IngredientRequestBody;
+import com.askie01.recipeapplication.exception.RecipeNotFoundException;
+import com.askie01.recipeapplication.model.entity.Customer;
+import com.askie01.recipeapplication.model.entity.Recipe;
+import com.askie01.recipeapplication.model.entity.value.Difficulty;
+import com.askie01.recipeapplication.repository.CustomerRepositoryV1;
+import com.askie01.recipeapplication.repository.RecipeRepositoryV3;
+import com.askie01.recipeapplication.service.RecipeServiceV3;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.AutoConfigureDataJpa;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.client.RestTestClient;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@AutoConfigureMockMvc
+@AutoConfigureDataJpa
+@AutoConfigureRestTestClient
+@TestPropertySource(properties = "api.recipe.v3.enabled=true")
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@DisplayName("RecipeRestControllerV3LoggingAspect integration tests")
+@EnabledIfSystemProperty(named = "test.type", matches = "integration")
+class RecipeRestControllerV3LoggingAspectIntegrationTest {
+
+    @MockitoSpyBean
+    private final RecipeRestControllerV3LoggingAspect aspect;
+
+    @MockitoBean
+    private final RecipeServiceV3 service;
+    private final RecipeRepositoryV3 recipeRepository;
+    private final CustomerRepositoryV1 customerRepository;
+
+    private final MockMvc mockMvc;
+    private final RestTestClient restTestClient;
+
+    private CustomerRecipeRequestBody requestBody;
+
+    @BeforeEach
+    void setUp() {
+        this.requestBody = getTestCustomerRecipeRequestBody();
+    }
+
+    private static CustomerRecipeRequestBody getTestCustomerRecipeRequestBody() {
+        return CustomerRecipeRequestBody.builder()
+                .name("Customer recipe name")
+                .description("Customer recipe description")
+                .difficulty(Difficulty.EASY)
+                .categories(new HashSet<>(Set.of(
+                        "First category",
+                        "Second category"))
+                )
+                .ingredients(new HashSet<>(Set.of(
+                        new IngredientRequestBody("First ingredient", 10.0d, "First unit"),
+                        new IngredientRequestBody("Second ingredient", 20.0d, "Second unit")
+                )))
+                .servings(10.0d)
+                .cookingTime(10)
+                .instructions("Customer recipe instructions")
+                .build();
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when createRecipe is called with authenticated user and valid request body")
+    void aspect_whenCreateRecipeIsCalledWithAuthenticatedUser_andValidRequestBody_logsTwoStatements() {
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        restTestClient.post().uri("/api/v3/recipes")
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .body(requestBody)
+                .exchange()
+                .expectStatus()
+                .isCreated();
+        verify(aspect, times(1)).logBeforeCreateRecipe(any());
+        verify(aspect, times(1)).logAfterCreateRecipe(any());
+    }
+
+    @Test
+    @DisplayName("aspect should skip log statements when createRecipe is called with authenticated user and invalid request body")
+    void aspect_whenCreateRecipeIsCalledWithAuthenticatedUser_andInvalidRequestBody_skipsLogStatements() {
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        restTestClient.post().uri("/api/v3/recipes")
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .body(new CustomerRecipeRequestBody())
+                .exchange()
+                .expectStatus()
+                .isBadRequest();
+        verifyNoInteractions(aspect);
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when createRecipe call throws an exception")
+    void aspect_whenCreateRecipeCallThrowsAnException_logsTwoStatements() throws Throwable {
+        doThrow(RuntimeException.class)
+                .when(service)
+                .createRecipe(
+                        any(String.class),
+                        any(CustomerRecipeRequestBody.class)
+                );
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        restTestClient.post().uri("/api/v3/recipes")
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .body(requestBody)
+                .exchange()
+                .expectStatus()
+                .is5xxServerError();
+        verify(aspect, times(1)).logBeforeCreateRecipe(any());
+        verify(aspect, times(1)).logAndRethrowCreateRecipe(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when getRecipe is called with existing id")
+    void aspect_whenGetRecipeIsCalledWithExistingId_logsTwoStatements() {
+        final Long id = recipeRepository.findAll().getFirst().getId();
+        final Recipe recipe = Recipe.builder()
+                .id(id)
+                .categories(new HashSet<>())
+                .ingredients(new HashSet<>())
+                .build();
+        when(service.getRecipe(any(Long.class)))
+                .thenReturn(recipe);
+        restTestClient.get().uri("/api/v3/recipes/{id}", id)
+                .exchange()
+                .expectStatus()
+                .isOk();
+        verify(aspect, times(1)).logBeforeGetRecipe(any());
+        verify(aspect, times(1)).logAfterGetRecipe(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when getRecipe is called with non-existing id")
+    void aspect_whenGetRecipeIsCalledWithNonExistingId_logsTwoStatements() throws Throwable {
+        when(service.getRecipe(any(Long.class)))
+                .thenThrow(RecipeNotFoundException.class);
+        final Long id = Long.MAX_VALUE;
+        restTestClient.get().uri("/api/v3/recipes/{id}", id)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+        verify(aspect, times(1)).logBeforeGetRecipe(any());
+        verify(aspect, times(1)).logAndRethrowGetRecipe(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when getRecipeImage is called with existing id")
+    void aspect_whenGetRecipeImageIsCalledWithExistingId_logsTwoStatements() {
+        final Long id = recipeRepository.findAll().getFirst().getId();
+        restTestClient.get().uri("/api/v3/recipes/{id}/image", id)
+                .exchange()
+                .expectStatus()
+                .isOk();
+        verify(aspect, times(1)).logBeforeGetRecipeImage(any());
+        verify(aspect, times(1)).logAfterGetRecipeImage(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when getRecipeImage is called with non-existing id")
+    void aspect_whenGetRecipeImageIsCalledWithNonExistingId_logsTwoStatements() throws Throwable {
+        when(service.getRecipeImage(any(Long.class)))
+                .thenThrow(RecipeNotFoundException.class);
+        final Long id = Long.MAX_VALUE;
+        restTestClient.get().uri("/api/v3/recipes/{id}/image", id)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+        verify(aspect, times(1)).logBeforeGetRecipeImage(any());
+        verify(aspect, times(1)).logAndRethrowGetRecipeImage(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when getUserRecipes is called with existing username")
+    void aspect_whenGetUserRecipesIsCalledWithExistingUsername_logsTwoStatements() {
+        when(service.getCustomerRecipes(
+                any(String.class),
+                any(Pageable.class)))
+                .thenReturn(Page.empty());
+        final String username = customerRepository.findAll().getFirst().getUsername();
+        restTestClient.get().uri("/api/v3/recipes?username={username}", username)
+                .exchange()
+                .expectStatus()
+                .isOk();
+        verify(aspect, times(1)).logBeforeGetUserRecipes(any());
+        verify(aspect, times(1)).logAfterGetUserRecipes(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when getUserRecipes call throws an exception")
+    void aspect_whenGetUserRecipesCallThrowsAnException_logsTwoStatements() throws Throwable {
+        when(service.getCustomerRecipes(
+                any(String.class),
+                any(Pageable.class)))
+                .thenThrow(UsernameNotFoundException.class);
+        final String username = customerRepository.findAll().getFirst().getUsername();
+        restTestClient.get().uri("/api/v3/recipes?username={username}", username)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+        verify(aspect, times(1)).logBeforeGetUserRecipes(any());
+        verify(aspect, times(1)).logAndRethrowGetUserRecipes(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when searchRecipes is called")
+    void aspect_whenSearchRecipesIsCalled_logsTwoStatements() {
+        when(service.searchRecipes(
+                any(String.class),
+                any(Pageable.class)))
+                .thenReturn(Page.empty());
+        final String query = recipeRepository.findAll().getFirst().getName();
+        restTestClient.get().uri("/api/v3/recipes/search?query={query}", query)
+                .exchange()
+                .expectStatus()
+                .isOk();
+        verify(aspect, times(1)).logBeforeSearchUserRecipes(any());
+        verify(aspect, times(1)).logAfterSearchUserRecipes(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when searchRecipes call throws an exception")
+    void aspect_whenSearchRecipesCallThrowsAnException_logsTwoStatements() throws Throwable {
+        when(service.searchRecipes(
+                any(String.class),
+                any(Pageable.class)))
+                .thenThrow(RuntimeException.class);
+        final String query = recipeRepository.findAll().getFirst().getName();
+        restTestClient.get().uri("/api/v3/recipes/search?query={query}", query)
+                .exchange()
+                .expectStatus()
+                .is5xxServerError();
+        verify(aspect, times(1)).logBeforeSearchUserRecipes(any());
+        verify(aspect, times(1)).logAndRethrowSearchUserRecipes(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when updateRecipeDetails is called")
+    void aspect_whenUpdateRecipeDetailsIsCalled_logsTwoStatements() {
+        final Long id = recipeRepository.findAll().getFirst().getId();
+        restTestClient.put().uri("/api/v3/recipes/{id}", id)
+                .headers(headers -> headers.setBasicAuth("user", "user"))
+                .body(requestBody)
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+        verify(aspect, times(1)).logBeforeUpdateRecipeDetails(any());
+        verify(aspect, times(1)).logAfterUpdateRecipeDetails(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when updateRecipeDetails call throws an exception")
+    void aspect_whenUpdateRecipeDetailsCallThrowsAnException_logsTwoStatements() throws Throwable {
+        doThrow(RuntimeException.class)
+                .when(service)
+                .updateRecipe(
+                        any(String.class),
+                        any(Long.class),
+                        any(CustomerRecipeRequestBody.class)
+                );
+        restTestClient.put().uri("/api/v3/recipes/{id}", 1L)
+                .headers(headers -> headers.setBasicAuth("user", "user"))
+                .body(requestBody)
+                .exchange()
+                .expectStatus()
+                .is5xxServerError();
+        verify(aspect, times(1)).logBeforeUpdateRecipeDetails(any());
+        verify(aspect, times(1)).logAndRethrowUpdateRecipeDetails(any());
+    }
+
+    @Test
+    @WithMockUser(username = "user", password = "user")
+    @DisplayName("aspect should log two statements when updateRecipeImage is called")
+    void aspect_whenUpdateRecipeImageIsCalled_logsTwoStatements() throws Exception {
+        final Long id = recipeRepository.findAll().getFirst().getId();
+        final MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "default-recipe.png",
+                MediaType.IMAGE_PNG_VALUE,
+                new ClassPathResource("static/default-recipe.png").getContentAsByteArray()
+        );
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/v3/recipes/{id}/image", id)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .file(image))
+                .andExpect(status().isNoContent());
+        verify(aspect, times(1)).logBeforeUpdateRecipeImage(any());
+        verify(aspect, times(1)).logAfterUpdateRecipeImage(any());
+    }
+
+    @Test
+    @WithMockUser(username = "user", password = "user")
+    @DisplayName("aspect should log two statements when updateRecipeImage call throws an exception")
+    void aspect_whenUpdateRecipeImageCallThrowsAnException_logsTwoStatements() throws Throwable {
+        doThrow(RuntimeException.class)
+                .when(service)
+                .updateImage(
+                        any(String.class),
+                        any(Long.class),
+                        any(MultipartFile.class)
+                );
+        final MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "default-recipe.png",
+                MediaType.IMAGE_PNG_VALUE,
+                new ClassPathResource("static/default-recipe.png").getContentAsByteArray()
+        );
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/v3/recipes/{id}/image", 1L)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .file(image))
+                .andExpect(status().is5xxServerError());
+        verify(aspect, times(1)).logBeforeUpdateRecipeImage(any());
+        verify(aspect, times(1)).logAndRethrowUpdateRecipeImage(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when restoreDefaultRecipeImage is called")
+    void aspect_whenRestoreDefaultRecipeImageIsCalled_logsTwoStatements() {
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        restTestClient.put().uri("/api/v3/recipes/{id}/image/restore", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+        verify(aspect, times(1)).logBeforeRestoreDefaultRecipeImage(any());
+        verify(aspect, times(1)).logAfterRestoreDefaultRecipeImage(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when restoreDefaultRecipeImage call throws an exception")
+    void aspect_whenRestoreDefaultRecipeImageCallThrowsAnException_logsTwoStatements() throws Throwable {
+        doThrow(RuntimeException.class)
+                .when(service)
+                .restoreDefaultImage(
+                        any(String.class),
+                        any(Long.class)
+                );
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        restTestClient.put().uri("/api/v3/recipes/{id}/image/restore", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .exchange()
+                .expectStatus()
+                .is5xxServerError();
+        verify(aspect, times(1)).logBeforeRestoreDefaultRecipeImage(any());
+        verify(aspect, times(1)).logAndRethrowRestoreDefaultRecipeImage(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when deleteRecipe is called")
+    void aspect_whenDeleteRecipeIsCalled_logsTwoStatements() {
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        restTestClient.delete().uri("/api/v3/recipes/{id}", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+        verify(aspect, times(1)).logBeforeDeleteRecipe(any());
+        verify(aspect, times(1)).logAfterDeleteRecipe(any());
+    }
+
+    @Test
+    @DisplayName("aspect should log two statements when deleteRecipe call throws an exception")
+    void aspect_whenDeleteRecipeCallThrowsAnException_logsTwoStatements() throws Throwable {
+        doThrow(RuntimeException.class)
+                .when(service)
+                .deleteRecipe(
+                        any(String.class),
+                        any(Long.class)
+                );
+        final Customer customer = customerRepository.findAll().getFirst();
+        final String username = customer.getUsername();
+        final String password = customer.getPassword().replace("{noop}", "");
+        final Long recipeId = customer.getRecipes().stream().findFirst().orElseThrow().getId();
+        restTestClient.delete().uri("/api/v3/recipes/{id}", recipeId)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .exchange()
+                .expectStatus()
+                .is5xxServerError();
+        verify(aspect, times(1)).logBeforeDeleteRecipe(any());
+        verify(aspect, times(1)).logAndRethrowDeleteRecipe(any());
+    }
+}


### PR DESCRIPTION
* Added missing validation annotation in `CustomerRecipeRequestBody` - now the customer need to meet specific criteria in order to create an recipe.
* Due to above changes - updated few `RecipeRestControllerV3` integration tests.
* Created `RecipeRestControllerV3LoggingAspect` to monitor traffic for Recipe API v3.
* Created integration tests for newly created logging aspect, to make sure it's working as expected in a spring environment.
* This pull request closes #538 