### PR TITLE
558 return recipe id on creation

### DIFF
--- a/src/main/java/com/askie01/recipeapplication/api/v3/RecipeRestControllerV3.java
+++ b/src/main/java/com/askie01/recipeapplication/api/v3/RecipeRestControllerV3.java
@@ -23,6 +23,8 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.net.URI;
+
 @Validated
 @RestController
 @RequestMapping("/api/v3/recipes")
@@ -38,8 +40,10 @@ public class RecipeRestControllerV3 {
     public ResponseEntity<Void> createRecipe(Authentication authentication,
                                              @Valid @RequestBody CustomerRecipeRequestBody requestBody) {
         final String username = authentication.getName();
-        service.createRecipe(username, requestBody);
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        final Long recipeId = service.createRecipe(username, requestBody);
+        return ResponseEntity
+                .created(URI.create("/api/v3/recipes/" + recipeId))
+                .build();
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/askie01/recipeapplication/model/entity/Recipe.java
+++ b/src/main/java/com/askie01/recipeapplication/model/entity/Recipe.java
@@ -19,7 +19,7 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
-@ToString
+@ToString(exclude = "image")
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "recipe")

--- a/src/main/java/com/askie01/recipeapplication/service/DefaultRecipeServiceV3.java
+++ b/src/main/java/com/askie01/recipeapplication/service/DefaultRecipeServiceV3.java
@@ -27,15 +27,17 @@ public class DefaultRecipeServiceV3 implements RecipeServiceV3 {
 
     @Override
     @SneakyThrows
-    public void createRecipe(String username, CustomerRecipeRequestBody requestBody) {
+    public Long createRecipe(String username, CustomerRecipeRequestBody requestBody) {
         final Customer customer = customerRepository
                 .findByUsernameIgnoreCase(username)
                 .orElseThrow(() -> new UsernameNotFoundException("Username: '" + username + "' does not exist"));
         final Recipe recipe = customerRecipeRequestBodyMapper.mapToEntity(requestBody);
         final byte[] defaultImage = classPathResource.getContentAsByteArray();
         recipe.setImage(defaultImage);
-        customer.getRecipes().add(recipe);
+        final Recipe savedRecipe = recipeRepository.save(recipe);
+        customer.getRecipes().add(savedRecipe);
         customerRepository.save(customer);
+        return savedRecipe.getId();
     }
 
     @Override

--- a/src/main/java/com/askie01/recipeapplication/service/RecipeServiceV3.java
+++ b/src/main/java/com/askie01/recipeapplication/service/RecipeServiceV3.java
@@ -8,7 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface RecipeServiceV3 {
 
-    void createRecipe(String username, CustomerRecipeRequestBody requestBody);
+    Long createRecipe(String username, CustomerRecipeRequestBody requestBody);
 
     Recipe getRecipe(Long id);
 

--- a/src/test/java/com/askie01/recipeapplication/unit/service/DefaultRecipeServiceV3UnitTest.java
+++ b/src/test/java/com/askie01/recipeapplication/unit/service/DefaultRecipeServiceV3UnitTest.java
@@ -91,6 +91,8 @@ class DefaultRecipeServiceV3UnitTest {
                 .thenReturn(Optional.of(customer));
         when(mapper.mapToEntity(any(CustomerRecipeRequestBody.class)))
                 .thenReturn(recipe);
+        when(recipeRepository.save(any(Recipe.class)))
+                .thenReturn(recipe);
 
         service.createRecipe("username", requestBody);
         verify(customerRepository, times(1))


### PR DESCRIPTION
* Updated the `RecipeServiceV3` interface & default implementation `createRecipe()` method to return newly created recipe ID for easier navigation.
* Updated test cases to ensure stability.
* This change reflects `RecipeRestControllerV3` response, so we adjusted that as well.
* Excluded `image` field from `toString()` method in `Recipe` entity for cleaner logs.
* This pull request closes #558